### PR TITLE
fix: use GA artifacts in CICD pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
       bake_target: ${{ matrix.targets }}
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
-      artifact_path: /artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
 
   test:
     name: Test
@@ -104,7 +104,7 @@ jobs:
     with:
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
-      artifact_path: /artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
 
   release:
     name: Release
@@ -118,7 +118,7 @@ jobs:
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
       release_tag: ${{ needs.prepare.outputs.release_tag }}
-      artifact_path: /artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
 
   success:
     name: Success

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
       bake_target: ${{ matrix.targets }}
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
-      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts-${{ needs.prepare.outputs.image_tag }}
 
   test:
     name: Test
@@ -104,7 +104,7 @@ jobs:
     with:
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
-      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts-${{ needs.prepare.outputs.image_tag }}
 
   release:
     name: Release
@@ -118,7 +118,7 @@ jobs:
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
       release_tag: ${{ needs.prepare.outputs.release_tag }}
-      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts-${{ needs.prepare.outputs.image_tag }}
 
   success:
     name: Success

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   verify:
-    name: Verify codebase changes
+    name: Verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -46,8 +46,8 @@ jobs:
             exit 1
           fi
 
-  prepare-build:
-    name: Prepare Build
+  prepare:
+    name: Prepare
     needs:
       - verify
     outputs:
@@ -80,42 +80,45 @@ jobs:
         id: targets
         uses: docker/bake-action/subaction/list-targets@a4d7f0b5b91c14a296d792d4ec53a9db17f02e67 # v5.5.0
 
-  build-push:
+  build:
     name: ${{ matrix.targets }}
     needs:
-      - prepare-build
+      - prepare
     strategy:
       fail-fast: false
       matrix:
-        targets: ${{ fromJson(needs.prepare-build.outputs.targets) }}
-    uses: ./.github/workflows/reusable-build-push.yaml
+        targets: ${{ fromJson(needs.prepare.outputs.targets) }}
+    uses: ./.github/workflows/reusable-build.yaml
     with:
       bake_target: ${{ matrix.targets }}
       image_repo: ghcr.io/agntcy
-      image_tag: ${{ needs.prepare-build.outputs.image_tag }}
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
 
   test:
     name: Test
     needs:
-      - prepare-build
-      - build-push
+      - prepare
+      - build
     uses: ./.github/workflows/reusable-test.yaml
     with:
       image_repo: ghcr.io/agntcy
-      image_tag: ${{ needs.prepare-build.outputs.image_tag }}
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
+      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
 
   release:
     name: Release
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs:
-      - prepare-build
-      - build-push
+      - prepare
+      - build
       - test
     uses: ./.github/workflows/reusable-release.yaml
     with:
       image_repo: ghcr.io/agntcy
-      image_tag: ${{ needs.prepare-build.outputs.image_tag }}
-      release_tag: ${{ needs.prepare-build.outputs.release_tag }}
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
+      release_tag: ${{ needs.prepare.outputs.release_tag }}
+      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
 
   success:
     name: Success
@@ -123,8 +126,8 @@ jobs:
     # https://github.com/actions/toolkit/issues/581
     if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'failure') }}
     needs:
-      - prepare-build
-      - build-push
+      - prepare
+      - build
       - test
       - release
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
       bake_target: ${{ matrix.targets }}
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
-      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: /artifacts/${{ needs.prepare.outputs.image_tag }}
 
   test:
     name: Test
@@ -104,7 +104,7 @@ jobs:
     with:
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
-      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: /artifacts/${{ needs.prepare.outputs.image_tag }}
 
   release:
     name: Release
@@ -118,7 +118,7 @@ jobs:
       image_repo: ghcr.io/agntcy
       image_tag: ${{ needs.prepare.outputs.image_tag }}
       release_tag: ${{ needs.prepare.outputs.release_tag }}
-      artifact_path: artifacts/${{ needs.prepare.outputs.image_tag }}
+      artifact_path: /artifacts/${{ needs.prepare.outputs.image_tag }}
 
   success:
     name: Success

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        with:
+          driver: docker
+          platforms: linux/amd64,linux/arm64
 
       - name: Cache Docker layers
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Cisco and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Build and Push
+name: Build
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ on:
       bake_target:
         required: true
         type: string
-        description: "Bake target to build and push"
+        description: "Bake target to build"
       image_repo:
         required: true
         type: string
@@ -18,23 +18,20 @@ on:
         required: true
         type: string
         description: "Image tag to use."
+      artifact_path:
+        required: true
+        type: string
+        description: "Path where to upload the image artifacts."
 
 jobs:
-  build-and-push:
-    name: Build and Push
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           fetch-depth: 0
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: notused
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
@@ -63,7 +60,7 @@ jobs:
       - name: Create cache directory
         run: mkdir -p /tmp/.buildx-cache
 
-      - name: Build and push
+      - name: Build image artifact
         uses: docker/bake-action@a4d7f0b5b91c14a296d792d4ec53a9db17f02e67 # v5.5.0
         with:
           files: |
@@ -73,10 +70,26 @@ jobs:
           provenance: false
           set: |
             *.platform=linux/amd64,linux/arm64
-            *.output=type=registry
             *.cache-to=type=local,dest=/tmp/.buildx-cache
             *.cache-from=type=local,src=/tmp/.buildx-cache
             *.cache-from=type=registry,ref=${{ inputs.image_repo }}/${{ inputs.bake_target }}
+            *.output=type=tar,dest=/tmp/${{ inputs.bake_target }}.tar
         env:
           IMAGE_REPO: ${{ inputs.image_repo }}
           IMAGE_TAG: ${{ inputs.image_tag }}
+
+      - name: Save image artifact
+        run: |
+          mkdir -p ${{ inputs.artifact_path }}
+          mv "/tmp/${{ inputs.bake_target }}.tar" ${{ inputs.artifact_path }}
+
+      - name: Upload image artifact
+        id: upload-artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: ${{ inputs.bake_target }}
+          path: ${{ inputs.artifact_path }}/${{ inputs.bake_target }}.tar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-        with:
-          platforms: linux/amd64,linux/arm64
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
@@ -71,7 +69,7 @@ jobs:
           targets: ${{ inputs.bake_target }}
           provenance: false
           set: |
-            *.platform=linux/amd64,linux/arm64
+            *.platform=linux/amd64
             *.cache-to=type=local,dest=/tmp/.buildx-cache
             *.cache-from=type=local,src=/tmp/.buildx-cache
             *.cache-from=type=registry,ref=${{ inputs.image_repo }}/${{ inputs.bake_target }}
@@ -90,8 +88,3 @@ jobs:
           retention-days: 1
           compression-level: 0
           overwrite: true
-
-      - name: Load images to local Docker registry
-        run: |
-          docker load --input "/tmp/${{ inputs.bake_target }}.tar"
-          docker images

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -73,7 +73,7 @@ jobs:
             *.cache-to=type=local,dest=/tmp/.buildx-cache
             *.cache-from=type=local,src=/tmp/.buildx-cache
             *.cache-from=type=registry,ref=${{ inputs.image_repo }}/${{ inputs.bake_target }}
-            *.output=type=tar,dest=/tmp/${{ inputs.bake_target }}.tar
+            *.output=type=oci,dest=/tmp/${{ inputs.bake_target }}.tar
         env:
           IMAGE_REPO: ${{ inputs.image_repo }}
           IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -75,7 +75,7 @@ jobs:
             *.cache-to=type=local,dest=/tmp/.buildx-cache
             *.cache-from=type=local,src=/tmp/.buildx-cache
             *.cache-from=type=registry,ref=${{ inputs.image_repo }}/${{ inputs.bake_target }}
-            *.output=type=oci,dest=/tmp/${{ inputs.bake_target }}.tar
+            *.output=type=docker,dest=/tmp/${{ inputs.bake_target }}.tar
         env:
           IMAGE_REPO: ${{ inputs.image_repo }}
           IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -90,3 +90,8 @@ jobs:
           retention-days: 1
           compression-level: 0
           overwrite: true
+
+      - name: Load images to local Docker registry
+        run: |
+          docker load --input "/tmp/${{ inputs.bake_target }}.tar"
+          docker images

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -78,17 +78,12 @@ jobs:
           IMAGE_REPO: ${{ inputs.image_repo }}
           IMAGE_TAG: ${{ inputs.image_tag }}
 
-      - name: Save image artifact
-        run: |
-          mkdir -p ${{ inputs.artifact_path }}
-          mv "/tmp/${{ inputs.bake_target }}.tar" ${{ inputs.artifact_path }}
-
       - name: Upload image artifact
         id: upload-artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: ${{ inputs.bake_target }}
-          path: ${{ inputs.artifact_path }}/${{ inputs.bake_target }}.tar
+          name: ${{ inputs.artifact_path }}
+          path: /tmp/${{ inputs.bake_target }}.tar
           if-no-files-found: error
           retention-days: 1
           compression-level: 0

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -33,11 +33,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
-        with:
-          driver: docker
-          platforms: linux/amd64,linux/arm64
 
       - name: Cache Docker layers
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -33,9 +33,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -18,6 +18,10 @@ on:
         required: true
         type: string
         description: "Release tag for all components."
+      artifact_path:
+        required: true
+        type: string
+        description: "Path from where to download image artifacts."
       helm-version:
         required: false
         default: "3.12.1"
@@ -49,6 +53,19 @@ jobs:
           registry: ghcr.io
           username: notused
           password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: ${{ inputs.artifact_path }}
+          merge-multiple: true
+
+      - name: Load images to local Docker registry
+        run: |
+          for image_archive in ${{ inputs.artifact_path }}/*.tar; do
+            docker load --input "$image_archive"
+          done
+          docker images
 
       - name: Release images
         env:

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -47,21 +47,18 @@ jobs:
         shell: bash
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
-      - name: Create artifacts download directory
-        run: mkdir -p /tmp/artifacts
-
       - name: Download artifacts
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: ${{ inputs.artifact_path }}
-          path: /tmp/artifacts
+          path: artifacts
           pattern: "*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry
         run: |
-          ls -la /tmp/artifacts
-          for image_archive in /tmp/artifacts/*.tar; do
+          ls -la artifacts
+          for image_archive in artifacts/*.tar; do
             docker load --input "$image_archive"
           done
           docker images

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: ${{ inputs.artifact_path }}
-          pattern: "*.tar"
+          pattern: "**/*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -33,31 +33,25 @@ jobs:
     name: Images
     runs-on: ubuntu-latest
     steps:
-      - name: Install Skopeo
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo
-
       - name: Checkout code
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           fetch-depth: 0
 
+      - name: Setup Skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
       - name: Setup Taskfile
         shell: bash
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: notused
-          password: ${{ secrets.GITHUB_TOKEN  }}
-
       - name: Download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: ${{ inputs.artifact_path }}
+          pattern: "*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry
@@ -66,6 +60,13 @@ jobs:
             docker load --input "$image_archive"
           done
           docker images
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: notused
+          password: ${{ secrets.GITHUB_TOKEN  }}
 
       - name: Release images
         env:

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -47,16 +47,21 @@ jobs:
         shell: bash
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
+      - name: Create artifacts download directory
+        run: mkdir -p /tmp/artifacts
+
       - name: Download artifacts
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          path: ${{ inputs.artifact_path }}
-          pattern: "**/*.tar"
+          name: ${{ inputs.artifact_path }}
+          path: /tmp/artifacts
+          pattern: "*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry
         run: |
-          for image_archive in ${{ inputs.artifact_path }}/*.tar; do
+          ls -la /tmp/artifacts
+          for image_archive in /tmp/artifacts/*.tar; do
             docker load --input "$image_archive"
           done
           docker images

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -34,9 +34,10 @@ jobs:
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
       - name: Download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: ${{ inputs.artifact_path }}
+          pattern: "*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: ${{ inputs.artifact_path }}
-          pattern: "*.tar"
+          pattern: "**/*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Load images to local Docker registry
         run: |
+          ls -la ${{ inputs.artifact_path }}
           for image_archive in ${{ inputs.artifact_path }}/*.tar; do
             docker load --input "$image_archive"
           done

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -33,17 +33,21 @@ jobs:
         shell: bash
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
+      - name: Create artifacts download directory
+        run: mkdir -p /tmp/artifacts
+
       - name: Download artifacts
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          path: ${{ inputs.artifact_path }}
-          pattern: "**/*.tar"
+          name: ${{ inputs.artifact_path }}
+          path: /tmp/artifacts
+          pattern: "*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry
         run: |
-          ls -la ${{ inputs.artifact_path }}
-          for image_archive in ${{ inputs.artifact_path }}/*.tar; do
+          ls -la /tmp/artifacts
+          for image_archive in /tmp/artifacts/*.tar; do
             docker load --input "$image_archive"
           done
           docker images

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
         description: 'Image tag to use.'
+      artifact_path:
+        required: true
+        type: string
+        description: "Path from where to download image artifacts."
 
 jobs:
   test:
@@ -25,23 +29,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Login to ghcr.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: notused
-          password: ${{ secrets.GITHUB_TOKEN  }}
-
       - name: Setup Taskfile
         shell: bash
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
-      - name: Pull images
-        env:
-          IMAGE_REPO: ${{ inputs.image_repo }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
+      - name: Download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: ${{ inputs.artifact_path }}
+          merge-multiple: true
+
+      - name: Load images to local Docker registry
         run: |
-          task pull
+          for image_archive in ${{ inputs.artifact_path }}/*.tar; do
+            docker load --input "$image_archive"
+          done
+          docker images
 
       - name: Run tests
         env:

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -33,21 +33,18 @@ jobs:
         shell: bash
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
-      - name: Create artifacts download directory
-        run: mkdir -p /tmp/artifacts
-
       - name: Download artifacts
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: ${{ inputs.artifact_path }}
-          path: /tmp/artifacts
+          path: artifacts
           pattern: "*.tar"
           merge-multiple: true
 
       - name: Load images to local Docker registry
         run: |
-          ls -la /tmp/artifacts
-          for image_archive in /tmp/artifacts/*.tar; do
+          ls -la artifacts
+          for image_archive in artifacts/*.tar; do
             docker load --input "$image_archive"
           done
           docker images

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,23 +57,6 @@ tasks:
     cmds:
       - docker buildx bake {{.BAKE_OPTS}}
 
-  pull:
-    desc: Pull images for all components
-    cmds:
-      - |
-        images=$(docker buildx bake default --print | jq -r '.target | with_entries(.value |= .tags[0]) | to_entries[] | .value')
-        echo "$images" | while read image; do
-          echo "Pulling image: $image"
-          docker pull $image
-        done
-
-  push:
-    desc: Push images for all components
-    prompt:
-      - Are you sure you want to push the images to remote registry?
-    cmds:
-      - docker buildx bake default --set=*.output=type=registry
-
   release:
     desc: Release images for all components with a release tag
     prompt:
@@ -86,6 +69,7 @@ tasks:
         images=$(docker buildx bake default --print | jq -r '.target | with_entries(.value |= .tags[0]) | to_entries[] | .value')
         echo "$images" | while read image; do
           release_image="${image%%:*}:{{.RELEASE_TAG}}"
+          echo "Releasing image: $image --> $release_image"
           skopeo copy --multi-arch all docker://$image docker://$release_image
         done
 


### PR DESCRIPTION
Do not release images in non-release workflow runs. Instead use Github Action artifacts to share images between jobs