### PR TITLE
feat: separate skills from classes

### DIFF
--- a/schema/domains/trust_and_safety/content_moderation.json
+++ b/schema/domains/trust_and_safety/content_moderation.json
@@ -2,7 +2,7 @@
     "uid": 2,
     "caption": "Content Moderation",
     "description": "Reviewing and managing user-generated content to ensure it complies with community guidelines and legal standards. Subdomains: Automated Moderation, Community Guidelines, Human Moderation, and Harmful Content Detection.",
-    "extends": "trust_and_safety",
-    "name": "content_moderation",
+    "extends": "trust_and_safety_domain",
+    "name": "content_moderation_domain",
     "attributes": {}
   }

--- a/schema/domains/trust_and_safety/data_privacy.json
+++ b/schema/domains/trust_and_safety/data_privacy.json
@@ -2,7 +2,7 @@
     "uid": 4,
     "caption": "Data Privacy",
     "description": "Safeguarding personal information from unauthorized access and ensuring compliance with privacy laws and regulations. Subdomains: Privacy Regulations Compliance, Data Encryption, Data Anonymization, and User Consent Management.",
-    "extends": "trust_and_safety",
+    "extends": "trust_and_safety_domain",
     "name": "data_privacy",
     "attributes": {}
   }

--- a/schema/domains/trust_and_safety/fraud_prevention.json
+++ b/schema/domains/trust_and_safety/fraud_prevention.json
@@ -2,7 +2,7 @@
     "uid": 3,
     "caption": "Fraud Prevention",
     "description": "Identifying and stopping fraudulent activities to protect individuals and organizations from financial and reputational damage. Subdomains: Transaction Monitoring, Identity Verification, Fraud Analytics, and Fraud Awareness Training.",
-    "extends": "trust_and_safety",
+    "extends": "trust_and_safety_domain",
     "name": "fraud_prevention",
     "attributes": {}
   }

--- a/schema/domains/trust_and_safety/online_safety.json
+++ b/schema/domains/trust_and_safety/online_safety.json
@@ -2,7 +2,7 @@
     "uid": 1,
     "caption": "Online Safety",
     "description": "Protecting internet users from various forms of harm to ensure a secure digital environment. Subdomains: Cybersecurity Awareness, Child Online Protection, Identity Protection, and Digital Wellbeing.",
-    "extends": "trust_and_safety",
+    "extends": "trust_and_safety_domain",
     "name": "online_safety",
     "attributes": {}
   }

--- a/schema/domains/trust_and_safety/risk_management.json
+++ b/schema/domains/trust_and_safety/risk_management.json
@@ -2,7 +2,7 @@
     "uid": 5,
     "caption": "Risk Management",
     "description": "Identifying, assessing, and prioritizing risks to minimize their impact on an organization's objectives and operations. Subdomains: Risk Assessment, Mitigation Strategies, Crisis Management, and Compliance and Auditing.",
-    "extends": "trust_and_safety",
+    "extends": "trust_and_safety_domain",
     "name": "risk_management",
     "attributes": {}
   }

--- a/schema/domains/trust_and_safety/trust_and_safety.json
+++ b/schema/domains/trust_and_safety/trust_and_safety.json
@@ -2,7 +2,7 @@
   "caption": "Trust and Safety",
   "description": "Maintaining a secure and reliable environment, primarily online, by managing risks, preventing harm, and ensuring safety and privacy. Subdomains: Online Safety, Content Moderation, Fraud Prevention, Data Privacy, and Risk Management.",
   "extends": "base_domain",
-  "name": "trust_and_safety",
+  "name": "trust_and_safety_domain",
   "category": "trust_and_safety",
   "attributes": {}
 }

--- a/schema/features/evaluation/evaluation.json
+++ b/schema/features/evaluation/evaluation.json
@@ -4,36 +4,5 @@
   "description": "Assessing actions and outcomes to determine their effectiveness, guiding future decision-making and enhancing personal agency.",
   "extends": "base_feature",
   "name": "evaluation",
-  "attributes": {
-    "quality": {
-      "uid": 1,
-      "caption": "Quality",
-      "requirement": "recommended"
-    },
-    "performance": {
-      "uid": 2,
-      "caption": "Performance",
-      "requirement": "recommended"
-    },
-    "rating": {
-      "uid": 3,
-      "caption": "Rating",
-      "requirement": "recommended"
-    },
-    "supported_scores": {
-      "uid": 4,
-      "caption": "Supported Scores",
-      "requirement": "recommended"
-    },
-    "trust_and_safety": {
-      "uid": 5,
-      "caption": "Trust and Safety",
-      "requirement": "recommended"
-    },
-    "sustainability": {
-      "uid": 6,
-      "caption": "Sustainability",
-      "requirement": "recommended"
-    }
-  }
+  "attributes": {}
 }

--- a/schema/features/evaluation/trust_and_safety.json
+++ b/schema/features/evaluation/trust_and_safety.json
@@ -3,6 +3,6 @@
   "caption": "Trust and Safety(/MAA_Agent)",
   "description": "Values: Bias\nMisinformation\nToxicity\nIllegal Activity\nPersonal Safety\nPII Leakage\nPrompt Leakage\nUnauthorized Access\nIntellectual Property\nExcessive Agency\nRobustness\nGraphic Content\nCompetition\nInput & Output PII\nInput & Output Tone\nInput & Output Toxicity\nInput & Output Sexism\nPrompt Injection\nNumber of unauthorized agent calls blocked.\nData compliance adherence (GDPR, HIPAA, etc.)\nRobustness to adversarial attacks",
   "extends": "evaluation",
-  "name": "trust_and_safety",
+  "name": "trust_and_safety_feature",
   "attributes": {}
 }

--- a/schema/main_domains.json
+++ b/schema/main_domains.json
@@ -44,7 +44,7 @@
       "description": "Systems and processes involved in the movement of goods and people, as well as the physical infrastructure supporting them. Subdomains: Logistics, Automotive, Public Transit, Supply Chain, Freight, and Autonomous Vehicles."
     },
     "finance_and_business": {
-      "uid": 2,
+      "uid": 1,
       "caption": "Finance and Business",
       "description": "Managing money, investments, and financial risks within businesses or for individuals. Subdomains: Corporate Finance, Personal Finance, Risk Management, Accounting, and Financial Analysis."
     }

--- a/schema/skills/nlp/ethical_interaction/content_moderation.json
+++ b/schema/skills/nlp/ethical_interaction/content_moderation.json
@@ -3,6 +3,6 @@
   "caption": "Content Moderation",
   "description": "Avoiding the generation of harmful, inappropriate, or sensitive content.",
   "extends": "ethical_interaction",
-  "name": "content_moderation",
+  "name": "content_moderation_skill",
   "attributes": {}
 }

--- a/server/lib/schema.ex
+++ b/server/lib/schema.ex
@@ -825,7 +825,7 @@ defmodule Schema do
   defp reduce_main_domain(data) do
     Map.update(data, :classes, [], fn domains ->
       Enum.into(domains, %{}, fn {name, domain} ->
-        {name, reduce_domain(domain)}
+        {name, reduce_class(domain)}
       end)
     end)
   end
@@ -837,7 +837,7 @@ defmodule Schema do
   defp reduce_main_feature(data) do
     Map.update(data, :classes, [], fn features ->
       Enum.into(features, %{}, fn {name, feature} ->
-        {name, reduce_feature(feature)}
+        {name, reduce_class(feature)}
       end)
     end)
   end
@@ -897,16 +897,6 @@ defmodule Schema do
 
   @spec reduce_class(map) :: map
   def reduce_class(data) do
-    delete_attributes(data) |> delete_associations()
-  end
-
-  @spec reduce_domain(map) :: map
-  def reduce_domain(data) do
-    delete_attributes(data) |> delete_associations()
-  end
-
-  @spec reduce_feature(map) :: map
-  def reduce_feature(data) do
     delete_attributes(data) |> delete_associations()
   end
 

--- a/server/lib/schema.ex
+++ b/server/lib/schema.ex
@@ -791,19 +791,19 @@ defmodule Schema do
   end
 
   defp get_main_domain(id) do
-    Repo.main_domain(id) |> reduce_main_domain()
+    Repo.main_domain(id) |> reduce_category()
   end
 
   defp get_main_domain(extensions, id) do
-    Repo.main_domain(extensions, id) |> reduce_main_domain()
+    Repo.main_domain(extensions, id) |> reduce_category()
   end
 
   defp get_main_feature(id) do
-    Repo.main_feature(id) |> reduce_main_feature()
+    Repo.main_feature(id) |> reduce_category()
   end
 
   defp get_main_feature(extensions, id) do
-    Repo.main_feature(extensions, id) |> reduce_main_feature()
+    Repo.main_feature(extensions, id) |> reduce_category()
   end
 
   defp reduce_category(nil) do
@@ -814,30 +814,6 @@ defmodule Schema do
     Map.update(data, :classes, [], fn classes ->
       Enum.into(classes, %{}, fn {name, class} ->
         {name, reduce_class(class)}
-      end)
-    end)
-  end
-
-  defp reduce_main_domain(nil) do
-    nil
-  end
-
-  defp reduce_main_domain(data) do
-    Map.update(data, :classes, [], fn domains ->
-      Enum.into(domains, %{}, fn {name, domain} ->
-        {name, reduce_class(domain)}
-      end)
-    end)
-  end
-
-  defp reduce_main_feature(nil) do
-    nil
-  end
-
-  defp reduce_main_feature(data) do
-    Map.update(data, :classes, [], fn features ->
-      Enum.into(features, %{}, fn {name, feature} ->
-        {name, reduce_class(feature)}
       end)
     end)
   end

--- a/server/lib/schema.ex
+++ b/server/lib/schema.ex
@@ -113,13 +113,13 @@ defmodule Schema do
   @doc """
     Returns a single main domain with its classes.
   """
-  @spec main_domain(atom | String.t()) :: nil | Cache.main_domain_t()
+  @spec main_domain(atom | String.t()) :: nil | Cache.category_t()
   def main_domain(id), do: get_main_domain(Utils.to_uid(id))
 
-  @spec main_domain(Repo.extensions_t(), String.t()) :: nil | Cache.main_domain_t()
+  @spec main_domain(Repo.extensions_t(), String.t()) :: nil | Cache.category_t()
   def main_domain(extensions, id), do: get_main_domain(extensions, Utils.to_uid(id))
 
-  @spec main_domain(Repo.extensions_t(), String.t(), String.t()) :: nil | Cache.main_domain_t()
+  @spec main_domain(Repo.extensions_t(), String.t(), String.t()) :: nil | Cache.category_t()
   def main_domain(extensions, extension, id),
     do: get_main_domain(extensions, Utils.to_uid(extension, id))
 
@@ -143,13 +143,13 @@ defmodule Schema do
   @doc """
     Returns a single main feature with its classes.
   """
-  @spec main_feature(atom | String.t()) :: nil | Cache.main_feature_t()
+  @spec main_feature(atom | String.t()) :: nil | Cache.category_t()
   def main_feature(id), do: get_main_feature(Utils.to_uid(id))
 
-  @spec main_feature(Repo.extensions_t(), String.t()) :: nil | Cache.main_feature_t()
+  @spec main_feature(Repo.extensions_t(), String.t()) :: nil | Cache.category_t()
   def main_feature(extensions, id), do: get_main_feature(extensions, Utils.to_uid(id))
 
-  @spec main_feature(Repo.extensions_t(), String.t(), String.t()) :: nil | Cache.main_feature_t()
+  @spec main_feature(Repo.extensions_t(), String.t(), String.t()) :: nil | Cache.category_t()
   def main_feature(extensions, extension, id),
       do: get_main_feature(extensions, Utils.to_uid(extension, id))
 
@@ -296,7 +296,7 @@ defmodule Schema do
   @doc """
     Returns a single domain.
   """
-  @spec domain(atom() | String.t()) :: nil | Cache.domain_t()
+  @spec domain(atom() | String.t()) :: nil | Cache.class_t()
   def domain(id), do: Repo.domain(Utils.to_uid(id))
 
   @spec domain(nil | String.t(), String.t()) :: nil | map()
@@ -321,7 +321,7 @@ defmodule Schema do
   @doc """
     Returns a single domain with the embedded objects.
   """
-  @spec domain_ex(atom() | String.t()) :: nil | Cache.domain_t()
+  @spec domain_ex(atom() | String.t()) :: nil | Cache.class_t()
   def domain_ex(id),
     do: Repo.domain_ex(Utils.to_uid(id))
 
@@ -346,7 +346,7 @@ defmodule Schema do
   @doc """
   Finds a domain by the domain uid value.
   """
-  @spec find_domain(integer()) :: nil | Cache.domain_t()
+  @spec find_domain(integer()) :: nil | Cache.class_t()
   def find_domain(uid) when is_integer(uid), do: Repo.find_domain(uid)
 
   @doc """
@@ -371,7 +371,7 @@ defmodule Schema do
   @doc """
     Returns a single feature.
   """
-  @spec feature(atom() | String.t()) :: nil | Cache.feature_t()
+  @spec feature(atom() | String.t()) :: nil | Cache.class_t()
   def feature(id), do: Repo.feature(Utils.to_uid(id))
 
   @spec feature(nil | String.t(), String.t()) :: nil | map()
@@ -396,7 +396,7 @@ defmodule Schema do
   @doc """
     Returns a single feature with the embedded objects.
   """
-  @spec feature_ex(atom() | String.t()) :: nil | Cache.feature_t()
+  @spec feature_ex(atom() | String.t()) :: nil | Cache.class_t()
   def feature_ex(id),
       do: Repo.feature_ex(Utils.to_uid(id))
 
@@ -421,7 +421,7 @@ defmodule Schema do
   @doc """
   Finds a feature by the feature uid value.
   """
-  @spec find_feature(integer()) :: nil | Cache.feature_t()
+  @spec find_feature(integer()) :: nil | Cache.class_t()
   def find_feature(uid) when is_integer(uid), do: Repo.find_feature(uid)
 
   @doc """

--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -25,6 +25,7 @@ defmodule Schema.Cache do
     :dictionary,
     :base_class,
     :classes,
+    :all_classes,
     :objects,
     :all_objects,
     # domain libs
@@ -33,7 +34,7 @@ defmodule Schema.Cache do
     :main_domains,
     # skill libs
     :skills,
-    :all_classes,
+    :all_skills,
     :categories,
     # feature libs
     :features,
@@ -41,7 +42,7 @@ defmodule Schema.Cache do
     :main_features
   ]
   defstruct ~w[
-    version profiles dictionary base_class classes categories main_domains skills domains all_classes all_domains objects all_objects features all_features main_features
+    version profiles dictionary base_class classes all_classes categories main_domains skills all_skills domains all_domains objects all_objects features all_features main_features
   ]a
 
   @type t() :: %__MODULE__{}
@@ -71,7 +72,7 @@ defmodule Schema.Cache do
     dictionary = JsonReader.read_dictionary() |> update_dictionary()
     base_class = JsonReader.read_base_class()
 
-    {skills, all_classes, observable_type_id_map, categories} =
+    {skills, all_skills, observable_type_id_map, categories} =
       read_classes(base_class, @main_skills_file, @skills_dir)
 
     {domains, all_domains, _observable_domains_type_id_map, main_domains} =
@@ -82,6 +83,7 @@ defmodule Schema.Cache do
 
     # Merge skills, domains and features classes
     classes = Utils.merge_classes([skills, domains, features])
+    all_classes = Utils.merge_classes([all_skills, all_domains, all_features])
 
     {objects, all_objects, observable_type_id_map} = read_objects(observable_type_id_map)
 
@@ -152,11 +154,12 @@ defmodule Schema.Cache do
       dictionary: dictionary,
       base_class: base_class,
       classes: classes,
+      all_classes: all_classes,
       objects: objects,
       all_objects: all_objects,
       # skill libs
       skills: skills,
-      all_classes: all_classes,
+      all_skills: all_skills,
       categories: categories,
       # domain libs
       domains: domains,
@@ -287,6 +290,9 @@ defmodule Schema.Cache do
 
   @spec skills(__MODULE__.t()) :: map()
   def skills(%__MODULE__{skills: skills}), do: skills
+
+  @spec all_skills(__MODULE__.t()) :: map()
+  def all_skills(%__MODULE__{all_skills: all_skills}), do: all_skills
 
   @spec domains(__MODULE__.t()) :: map()
   def domains(%__MODULE__{domains: domains}), do: domains

--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -48,12 +48,8 @@ defmodule Schema.Cache do
 
   @type t() :: %__MODULE__{}
   @type class_t() :: map()
-  @type domain_t() :: map()
-  @type feature_t() :: map()
   @type object_t() :: map()
   @type category_t() :: map()
-  @type main_feature_t() :: map()
-  @type main_domain_t() :: map()
   @type dictionary_t() :: map()
 
   @main_skills_file "main_skills.json"
@@ -226,7 +222,7 @@ defmodule Schema.Cache do
   @spec main_domains(__MODULE__.t()) :: map()
   def main_domains(%__MODULE__{main_domains: main_domains}), do: main_domains
 
-  @spec main_domain(__MODULE__.t(), any) :: nil | main_domain_t()
+  @spec main_domain(__MODULE__.t(), any) :: nil | category_t()
   def main_domain(%__MODULE__{main_domains: main_domains}, id) do
     Map.get(main_domains[:attributes], id)
   end
@@ -234,7 +230,7 @@ defmodule Schema.Cache do
   @spec main_features(__MODULE__.t()) :: map()
   def main_features(%__MODULE__{main_features: main_features}), do: main_features
 
-  @spec main_feature(__MODULE__.t(), any) :: nil | main_feature_t()
+  @spec main_feature(__MODULE__.t(), any) :: nil | category_t()
   def main_feature(%__MODULE__{main_features: main_features}, id) do
     Map.get(main_features[:attributes], id)
   end
@@ -326,7 +322,7 @@ defmodule Schema.Cache do
     end)
   end
 
-  @spec domain(__MODULE__.t(), atom()) :: nil | domain_t()
+  @spec domain(__MODULE__.t(), atom()) :: nil | class_t()
   def domain(%__MODULE__{dictionary: dictionary, base_class: base_class}, :base_class) do
     enrich(base_class, dictionary[:attributes])
   end
@@ -344,7 +340,7 @@ defmodule Schema.Cache do
   @doc """
   Returns extended domain definition, which includes all objects referred by the domain.
   """
-  @spec domain_ex(__MODULE__.t(), atom()) :: nil | domain_t()
+  @spec domain_ex(__MODULE__.t(), atom()) :: nil | class_t()
   def domain_ex(
         %__MODULE__{dictionary: dictionary, objects: objects, base_class: base_class},
         :base_class
@@ -386,7 +382,7 @@ defmodule Schema.Cache do
     end)
   end
 
-  @spec feature(__MODULE__.t(), atom()) :: nil | feature_t()
+  @spec feature(__MODULE__.t(), atom()) :: nil | class_t()
   def feature(%__MODULE__{dictionary: dictionary, base_class: base_class}, :base_class) do
     enrich(base_class, dictionary[:attributes])
   end
@@ -404,7 +400,7 @@ defmodule Schema.Cache do
   @doc """
   Returns extended feature definition, which includes all objects referred by the feature.
   """
-  @spec feature_ex(__MODULE__.t(), atom()) :: nil | feature_t()
+  @spec feature_ex(__MODULE__.t(), atom()) :: nil | class_t()
   def feature_ex(
         %__MODULE__{dictionary: dictionary, objects: objects, base_class: base_class},
         :base_class

--- a/server/lib/schema/repo.ex
+++ b/server/lib/schema/repo.ex
@@ -81,6 +81,41 @@ defmodule Schema.Repo do
     end)
   end
 
+  @spec main_skills :: map()
+  def main_skills() do
+    Agent.get(__MODULE__, fn schema -> Cache.main_skills(schema) end)
+  end
+
+  @spec main_skills(extensions_t() | nil) :: map()
+  def main_skills(nil) do
+    Agent.get(__MODULE__, fn schema -> Cache.main_skills(schema) end)
+  end
+
+  def main_skills(extensions) do
+    Agent.get(__MODULE__, fn schema ->
+      Cache.main_skills(schema)
+      |> Map.update!(:attributes, fn attributes -> filter(attributes, extensions) end)
+    end)
+  end
+
+  @spec main_skill(atom) :: nil | Cache.main_skill_t()
+  def main_skill(id) do
+    main_skill(nil, id)
+  end
+
+  @spec main_skill(extensions_t() | nil, atom) :: nil | Cache.main_skill_t()
+  def main_skill(extensions, id) do
+    Agent.get(__MODULE__, fn schema ->
+      case Cache.main_skill(schema, id) do
+        nil ->
+          nil
+
+        main_skill ->
+          add_skills(extensions, {id, main_skill}, Cache.skills(schema))
+      end
+    end)
+  end
+
   @spec main_domains :: map()
   def main_domains() do
     Agent.get(__MODULE__, fn schema -> Cache.main_domains(schema) end)
@@ -194,6 +229,25 @@ defmodule Schema.Repo do
     Agent.get(__MODULE__, fn schema -> Cache.all_classes(schema) end)
   end
 
+  @spec skills() :: map()
+  def skills() do
+    Agent.get(__MODULE__, fn schema -> Cache.skills(schema) end)
+  end
+
+  @spec skills(extensions_t() | nil) :: map()
+  def skills(nil) do
+    Agent.get(__MODULE__, fn schema -> Cache.skills(schema) end)
+  end
+
+  def skills(extensions) do
+    Agent.get(__MODULE__, fn schema -> Cache.skills(schema) |> filter(extensions) end)
+  end
+
+  @spec all_skills() :: map()
+  def all_skills() do
+    Agent.get(__MODULE__, fn schema -> Cache.all_skills(schema) end)
+  end
+
   @spec domains() :: map()
   def domains() do
     Agent.get(__MODULE__, fn schema -> Cache.domains(schema) end)
@@ -303,6 +357,21 @@ defmodule Schema.Repo do
   @spec find_class(any) :: nil | map
   def find_class(uid) do
     Agent.get(__MODULE__, fn schema -> Cache.find_class(schema, uid) end)
+  end
+
+  @spec skill(atom) :: nil | Cache.class_t()
+  def skill(id) do
+    Agent.get(__MODULE__, fn schema -> Cache.skill(schema, id) end)
+  end
+
+  @spec skill_ex(atom) :: nil | Cache.class_t()
+  def skill_ex(id) do
+    Agent.get(__MODULE__, fn schema -> Cache.skill_ex(schema, id) end)
+  end
+
+  @spec find_skill(any) :: nil | map
+  def find_skill(uid) do
+    Agent.get(__MODULE__, fn schema -> Cache.find_skill(schema, uid) end)
   end
 
   @spec domain(atom) :: nil | Cache.class_t()
@@ -478,6 +547,52 @@ defmodule Schema.Repo do
       )
 
     Map.put(category, :classes, list)
+  end
+
+  defp add_skills(nil, {id, main_skill}, skills) do
+    main_skill_uid = Atom.to_string(id)
+
+    list =
+      skills
+      |> Stream.filter(fn {_name, skill} ->
+        md = Map.get(skill, :category)
+        md == main_skill_uid or Utils.to_uid(skill[:extension], md) == id
+      end)
+      |> Stream.map(fn {name, skill} ->
+        skill =
+          skill
+          |> Map.delete(:category)
+          |> Map.delete(:category_name)
+
+        {name, skill}
+      end)
+      |> Enum.to_list()
+
+    Map.put(main_skill, :classes, list)
+    |> Map.put(:name, main_skill_uid)
+  end
+
+  defp add_skills(extensions, {id, main_skill}, skills) do
+    main_skill_uid = Atom.to_string(id)
+
+    list =
+      Enum.filter(
+        skills,
+        fn {_name, skill} ->
+          md = skill[:category]
+
+          case skill[:extension] do
+            nil ->
+              md == main_skill_uid
+
+            ext ->
+              MapSet.member?(extensions, ext) and
+                (md == main_skill_uid or Utils.to_uid(ext, md) == id)
+          end
+        end
+      )
+
+    Map.put(main_skill, :classes, list)
   end
 
   defp add_domains(nil, {id, main_domain}, domains) do

--- a/server/lib/schema/repo.ex
+++ b/server/lib/schema/repo.ex
@@ -98,12 +98,12 @@ defmodule Schema.Repo do
     end)
   end
 
-  @spec main_domain(atom) :: nil | Cache.main_domain_t()
+  @spec main_domain(atom) :: nil | Cache.category_t()
   def main_domain(id) do
     main_domain(nil, id)
   end
 
-  @spec main_domain(extensions_t() | nil, atom) :: nil | Cache.main_domain_t()
+  @spec main_domain(extensions_t() | nil, atom) :: nil | Cache.category_t()
   def main_domain(extensions, id) do
     Agent.get(__MODULE__, fn schema ->
       case Cache.main_domain(schema, id) do
@@ -133,12 +133,12 @@ defmodule Schema.Repo do
     end)
   end
 
-  @spec main_feature(atom) :: nil | Cache.main_feature_t()
+  @spec main_feature(atom) :: nil | Cache.category_t()
   def main_feature(id) do
     main_feature(nil, id)
   end
 
-  @spec main_feature(extensions_t() | nil, atom) :: nil | Cache.main_feature_t()
+  @spec main_feature(extensions_t() | nil, atom) :: nil | Cache.category_t()
   def main_feature(extensions, id) do
     Agent.get(__MODULE__, fn schema ->
       case Cache.main_feature(schema, id) do
@@ -305,12 +305,12 @@ defmodule Schema.Repo do
     Agent.get(__MODULE__, fn schema -> Cache.find_class(schema, uid) end)
   end
 
-  @spec domain(atom) :: nil | Cache.domain_t()
+  @spec domain(atom) :: nil | Cache.class_t()
   def domain(id) do
     Agent.get(__MODULE__, fn schema -> Cache.domain(schema, id) end)
   end
 
-  @spec domain_ex(atom) :: nil | Cache.domain_t()
+  @spec domain_ex(atom) :: nil | Cache.class_t()
   def domain_ex(id) do
     Agent.get(__MODULE__, fn schema -> Cache.domain_ex(schema, id) end)
   end
@@ -320,12 +320,12 @@ defmodule Schema.Repo do
     Agent.get(__MODULE__, fn schema -> Cache.find_domain(schema, uid) end)
   end
 
-  @spec feature(atom) :: nil | Cache.feature_t()
+  @spec feature(atom) :: nil | Cache.class_t()
   def feature(id) do
     Agent.get(__MODULE__, fn schema -> Cache.feature(schema, id) end)
   end
 
-  @spec feature_ex(atom) :: nil | Cache.feature_t()
+  @spec feature_ex(atom) :: nil | Cache.class_t()
   def feature_ex(id) do
     Agent.get(__MODULE__, fn schema -> Cache.feature_ex(schema, id) end)
   end

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -328,6 +328,16 @@ defmodule Schema.Utils do
     )
   end
 
+  @spec merge_classes([map()]) :: map()
+  def merge_classes(maps) when is_list(maps) do
+    Enum.reduce(maps, %{}, fn map, acc ->
+      Map.merge(acc, map, fn
+        :base_class, val1, _val2 -> val1
+        key, _val1, _val2 -> raise ArgumentError, "Duplicate class names are forbidden: #{key}"
+      end)
+    end)
+  end
+
   @spec deep_merge(map | nil, map | nil) :: map | nil
   def deep_merge(left, right) when is_map(left) and is_map(right) do
     Map.merge(left, right, &deep_resolve/3)

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -338,6 +338,15 @@ defmodule Schema.Utils do
     end)
   end
 
+  @spec merge_categories([map()]) :: map()
+  def merge_categories(maps) when is_list(maps) do
+    Enum.reduce(maps, %{}, fn map, acc ->
+      Map.merge(acc, map, fn
+        key, _val1, _val2 -> raise ArgumentError, "Duplicate category names are forbidden: #{key}"
+      end)
+    end)
+  end
+
   @spec deep_merge(map | nil, map | nil) :: map | nil
   def deep_merge(left, right) when is_map(left) and is_map(right) do
     Map.merge(left, right, &deep_resolve/3)

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -582,6 +582,85 @@ defmodule SchemaWeb.SchemaController do
   end
 
   @doc """
+  Get the schema main skills.
+  """
+  swagger_path :main_skills do
+    get("/api/main_skills")
+    summary("List main skills")
+    description("Get OASF schema main skills.")
+    produces("application/json")
+    tag("skills")
+
+    parameters do
+      extensions(:query, :array, "Related extensions to include in response.",
+        items: [type: :string]
+      )
+    end
+
+    response(200, "Success")
+  end
+
+  @doc """
+  Returns the list of main skills.
+  """
+  @spec main_skills(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def main_skills(conn, params) do
+    send_json_resp(conn, main_skills(params))
+  end
+
+  @spec main_skills(map()) :: map()
+  def main_skills(params) do
+    parse_options(extensions(params)) |> Schema.main_skills()
+  end
+
+  @doc """
+  Get the skills defined in a given main skill.
+  """
+  swagger_path :main_skill do
+    get("/api/main_skills/{name}")
+    summary("List sub skills of main skill")
+
+    description(
+      "Get OASF schema skills defined in the named main skill. The main skill name may contain an" <>
+        " extension name. For example, \"dev/policy\"."
+    )
+
+    produces("application/json")
+    tag("skills")
+
+    parameters do
+      name(:path, :string, "Main skill name", required: true)
+
+      extensions(:query, :array, "Related extensions to include in response.",
+        items: [type: :string]
+      )
+    end
+
+    response(200, "Success")
+    response(404, "Main skill <code>name</code> not found")
+  end
+
+  @spec main_skill(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def main_skill(conn, %{"id" => id} = params) do
+    case main_skill_skills(params) do
+      nil ->
+        send_json_resp(conn, 404, %{error: "Main skill #{id} not found"})
+
+      data ->
+        send_json_resp(conn, data)
+    end
+  end
+
+  @spec main_skill_skills(map()) :: map() | nil
+  def main_skill_skills(params) do
+    name = params["id"]
+    extension = extension(params)
+    extensions = parse_options(extensions(params))
+
+    Schema.main_skill(extensions, extension, name)
+  end
+
+  @doc """
   Get the schema main domains.
   """
   swagger_path :main_domains do
@@ -882,6 +961,96 @@ defmodule SchemaWeb.SchemaController do
 
       profiles ->
         Schema.classes(extensions, profiles)
+    end
+  end
+
+  @doc """
+  Get a skill by name.
+  get /api/skills/:name
+  """
+  swagger_path :skill do
+    get("/api/skills/{name}")
+    summary("skill")
+
+    description(
+      "Get OASF schema skill by name. The skill name may contain an extension name." <>
+        " For example, \"dev/cpu_usage\"."
+    )
+
+    produces("application/json")
+    tag("skills")
+
+    parameters do
+      name(:path, :string, "skill name", required: true)
+      profiles(:query, :array, "Related profiles to include in response.", items: [type: :string])
+    end
+
+    response(200, "Success")
+    response(404, "skill <code>name</code> not found")
+  end
+
+  @spec skill(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def skill(conn, %{"id" => id} = params) do
+    skill(conn, id, params)
+  end
+
+  defp skill(conn, id, params) do
+    extension = extension(params)
+
+    case Schema.skill(extension, id, parse_options(profiles(params))) do
+      nil ->
+        send_json_resp(conn, 404, %{error: "skill #{id} not found"})
+
+      data ->
+        skill = add_objects(data, params)
+        send_json_resp(conn, skill)
+    end
+  end
+
+  @doc """
+  Get the schema skill.
+  """
+  swagger_path :skills do
+    get("/api/skills")
+    summary("List skills")
+    description("Get OASF schema skills.")
+    produces("application/json")
+    tag("skills")
+
+    parameters do
+      extensions(:query, :array, "Related extensions to include in response.",
+        items: [type: :string]
+      )
+
+      profiles(:query, :array, "Related profiles to include in response.", items: [type: :string])
+    end
+
+    response(200, "Success", :skillDesc)
+  end
+
+  @spec skills(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def skills(conn, params) do
+    skills =
+      Enum.map(skills(params), fn {_name, skill} ->
+        Schema.reduce_class(skill)
+      end)
+
+    send_json_resp(conn, skills)
+  end
+
+  @doc """
+  Returns the list of skills.
+  """
+  @spec skills(map) :: map
+  def skills(params) do
+    extensions = parse_options(extensions(params))
+
+    case parse_options(profiles(params)) do
+      nil ->
+        Schema.skills(extensions)
+
+      profiles ->
+        Schema.skills(extensions, profiles)
     end
   end
 

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -953,7 +953,7 @@ defmodule SchemaWeb.SchemaController do
   def domains(conn, params) do
     domains =
       Enum.map(domains(params), fn {_name, domain} ->
-        Schema.reduce_domain(domain)
+        Schema.reduce_class(domain)
       end)
 
     send_json_resp(conn, domains)
@@ -1043,7 +1043,7 @@ defmodule SchemaWeb.SchemaController do
   def features(conn, params) do
     features =
       Enum.map(features(params), fn {_name, feature} ->
-        Schema.reduce_feature(feature)
+        Schema.reduce_class(feature)
       end)
 
     send_json_resp(conn, features)

--- a/server/lib/schema_web/router.ex
+++ b/server/lib/schema_web/router.ex
@@ -25,19 +25,21 @@ defmodule SchemaWeb.Router do
   scope "/", SchemaWeb do
     pipe_through :browser
 
-    get "/", PageController, :categories
-    get "/categories", PageController, :categories
+    get "/", PageController, :main_skills
 
+    get "/categories", PageController, :categories
     get "/categories/:id", PageController, :categories
     get "/categories/:extension/:id", PageController, :categories
 
-    get "/main_domains", PageController, :main_domains
+    get "/main_skills", PageController, :main_skills
+    get "/main_skills/:id", PageController, :main_skills
+    get "/main_skills/:extension/:id", PageController, :main_skills
 
+    get "/main_domains", PageController, :main_domains
     get "/main_domains/:id", PageController, :main_domains
     get "/main_domains/:extension/:id", PageController, :main_domains
 
     get "/main_features", PageController, :main_features
-
     get "/main_features/:id", PageController, :main_features
     get "/main_features/:extension/:id", PageController, :main_features
 
@@ -51,6 +53,10 @@ defmodule SchemaWeb.Router do
 
     get "/class/graph/:id", PageController, :class_graph
     get "/class/graph/:extension/:id", PageController, :class_graph
+
+    get "/skills", PageController, :skills
+    get "/skills/:id", PageController, :skills
+    get "/skills/:extension/:id", PageController, :skills
 
     get "/domains", PageController, :domains
     get "/domains/:id", PageController, :domains
@@ -79,11 +85,6 @@ defmodule SchemaWeb.Router do
     get "/data_types", PageController, :data_types
 
     get "/agent_model", PageController, :agent_model
-
-    get "/skills", PageController, :categories
-
-    get "/skills/:id", PageController, :categories
-    get "/skills/:extension/:id", PageController, :categories
   end
 
   # Other scopes may use custom stacks.
@@ -100,6 +101,10 @@ defmodule SchemaWeb.Router do
     get "/categories/:id", SchemaController, :category
     get "/categories/:extension/:id", SchemaController, :category
 
+    get "/main_skills", SchemaController, :main_skills
+    get "/main_skills/:id", SchemaController, :main_skill
+    get "/main_skills/:extension/:id", SchemaController, :main_skill
+
     get "/main_domains", SchemaController, :main_domains
     get "/main_domains/:id", SchemaController, :main_domain
     get "/main_domains/:extension/:id", SchemaController, :main_domain
@@ -114,6 +119,10 @@ defmodule SchemaWeb.Router do
     get "/classes", SchemaController, :classes
     get "/classes/:id", SchemaController, :class
     get "/classes/:extension/:id", SchemaController, :class
+
+    get "/skills", SchemaController, :skills
+    get "/skills/:id", SchemaController, :skill
+    get "/skills/:extension/:id", SchemaController, :skill
 
     get "/domains", SchemaController, :domains
     get "/domains/:id", SchemaController, :domain
@@ -144,6 +153,9 @@ defmodule SchemaWeb.Router do
 
     get "/classes/:id", SchemaController, :json_class
     get "/classes/:extension/:id", SchemaController, :json_class
+
+    get "/skills/:id", SchemaController, :json_class
+    get "/skills/:extension/:id", SchemaController, :json_class
 
     get "/domains/:id", SchemaController, :json_class
     get "/domains/:extension/:id", SchemaController, :json_class
@@ -176,11 +188,11 @@ defmodule SchemaWeb.Router do
     get "/classes/:extension/:id", SchemaController, :sample_class
   end
 
-  #scope "/doc" do
+  # scope "/doc" do
   #  forward "/", PhoenixSwagger.Plug.SwaggerUI,
   #    otp_app: :schema_server,
   #    swagger_file: "swagger.json"
-  #end
+  # end
 
   def swagger_info do
     %{

--- a/server/lib/schema_web/templates/layout/app.html.eex
+++ b/server/lib/schema_web/templates/layout/app.html.eex
@@ -180,8 +180,8 @@ limitations under the License.
 
   <div class="collapse navbar-collapse" id="navbarCollapse">
     <ul class="extensions navbar-nav ml-auto">
-      <li id="categories_id" class="nav-item">
-        <a class="nav-link" href='<%= Routes.static_path(@conn, "/skills") %>'>Skills</a>
+      <li id="skills_id" class="nav-item">
+        <a class="nav-link" href='<%= Routes.static_path(@conn, "/main_skills") %>'>Skills</a>
       </li>
       <li id="domains_id" class="nav-item">
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/main_domains") %>'>Domains</a>

--- a/server/lib/schema_web/templates/page/category.html.eex
+++ b/server/lib/schema_web/templates/page/category.html.eex
@@ -15,7 +15,7 @@ limitations under the License.
     <h3><%= @data[:caption] %>
       <span class="text-secondary">
         [<%= @data[:uid] %>]<sup><%= @data[:extension] || "" %></sup>
-        <%= if @data[:class_type] == "class", do: "skill", else: @data[:class_type] %> category
+        <%= @data[:class_type] %> category
       </span>
     </h3>
     <div class="text-dark"><%= raw description(@data) %></div>

--- a/server/lib/schema_web/templates/page/class.html.eex
+++ b/server/lib/schema_web/templates/page/class.html.eex
@@ -25,11 +25,13 @@ limitations under the License.
 <div class="row">
   <div class="col-md move-up">
     <%
-    class_type = if @data[:class_type] == "class", do: "skill", else: @data[:class_type]
+    class_type = @data[:class_type]
 
     path = case class_type do
-      "skill" ->
+      "class" ->
         Routes.static_path(@conn, "/categories/" <> category)
+      "skill" ->
+        Routes.static_path(@conn, "/main_skills/" <> category)
       "feature" ->
         Routes.static_path(@conn, "/main_features/" <> category)
       "domain" ->

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -285,6 +285,7 @@ defmodule SchemaWeb.PageView do
     all_classes =
       case class_type do
         "class" -> Schema.all_classes()
+        "skill" -> Schema.all_skills()
         "domain" -> Schema.all_domains()
         "feature" -> Schema.all_features()
       end


### PR DESCRIPTION
1. Separated skills from classes and main_skills from categories in the cache, routes and controllers:

- now the generic classes and categories objects and endpoints respond with all the classes and all the categories
- the skills and main_skills endpoints respond only with the skill classes and skill categories

2. Refactored some parts along the way to have fewer code duplications.
3. Fixed some issues in the schema and ensured there are no duplicate class names