### PR TITLE
feat: add observability to the schema

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -29,6 +29,11 @@
       "type": "agent",
       "is_array": true
     },
+    "alerting": {
+      "caption": "Alerting",
+      "description": "Generates notifications or warnings based on predefined thresholds or detected anomalies in multi-agent operations.",
+      "type": "object"
+    },
     "algorithm": {
       "caption": "Algorithm",
       "description": "The applicable algorithm, normalized to the caption of 'algorithm_id'. See specific usage.",
@@ -50,8 +55,19 @@
         }
       }
     },
+    "anomaly_detection": {
+      "caption": "Anomaly Detection",
+      "description": "Identifies unusual patterns or behaviors in multi-agent systems, enabling proactive issue resolution.",
+      "type": "object"
+    },
     "annotations": {
       "caption": "Annotations",
+      "description": "Provides additional metadata associated with this release manifest.",
+      "type": "key_value_object",
+      "is_array": true
+    },
+    "attributes": {
+      "caption": "Attributes",
       "description": "Provides additional metadata associated with this release manifest.",
       "type": "key_value_object",
       "is_array": true
@@ -71,6 +87,12 @@
       "caption": "Callback Support",
       "description": "This is `true` if the agent supports a webhook to report run results. If this is `false`, providing a `webhook` at run creation has no effect. If missing, it means `false`.",
       "type": "boolean_t"
+    },
+    "carbon_footprint_analysis": {
+      "caption": "Carbon Footprint Analysis",
+      "description": "Evaluates the greenhouse gas emissions associated with the workflows of multi-agent systems, enabling strategies for reducing environmental impact.",
+      "type": "metric",
+      "is_array": true
     },
     "capabilities": {
       "caption": "Capabilities",
@@ -148,6 +170,49 @@
       "description": "This object contains an instance of an OpenAPI schema object.",
       "type": "json_t"
     },
+    "controllability": {
+      "caption": "Controllability",
+      "description": "",
+      "type": "metric",
+      "is_array": true,
+      "enum": {
+        "agentic_graph": {
+          "caption": "Agentic graph"
+        },
+        "topology_dynamism": {
+          "caption": "Measure for dynamism of topology."
+        },
+        "agentic_workflow_determinism": {
+          "caption": "Measure for degree of determinism of agentic workflow."
+        }
+      }
+    },
+    "cost": {
+      "caption": "Cost",
+      "description": "Cost related metrics that apply to an agent.",
+      "type": "metric",
+      "is_array": true,
+      "enum": {
+        "number_of_tokens": {
+          "caption": "Number of tokens"
+        },
+        "latency": {
+          "caption": "Latency"
+        }
+      },
+      "references": [
+        {
+          "description": "OpenTelemetry Specification",
+          "url": "https://opentelemetry.io/docs/specs/otel/metrics/"
+        }
+      ]
+    },
+    "cost_tracking": {
+      "caption": "Cost Tracking",
+      "description": "Monitors and analyzes the financial expenditure associated with multi-agent operations to ensure cost efficiency.",
+      "type": "metric",
+      "is_array": true
+    },
     "created_at": {
       "caption": "Created Time",
       "description": "The time when the object was created. See specific usage.",
@@ -162,6 +227,12 @@
       "caption": "Custom Streaming Update",
       "description": "This describes the format of an Update in the streaming. Must be specified if `streaming.custom` capability is true and cannot be specified otherwise. Format follows: <a target='_blank' href='https://spec.openapis.org/oas/v3.1.1.html#schema-object'>Schema Object</a>.",
       "type": "json_t"
+    },
+    "data_points": {
+      "caption": "Data Points",
+      "description": "The actual data points collected for the metric, which can be a single value or a collection of values over time.",
+      "type": "object",
+      "is_array": true
     },
     "dependencies": {
       "caption": "Agent Dependencies",
@@ -191,15 +262,34 @@
       "description": "The digest of the targeted content, conforming to the requirements. Retrieved content SHOULD be verified against this digest when consumed via untrusted sources. The digest property acts as a content identifier, enabling content addressability. It uniquely identifies content by taking a collision-resistant hash of the bytes. If the digest can be communicated in a secure manner, one can verify content from an insecure source by recalculating the digest independently, ensuring the content has not been modified. The value of the digest property is a string consisting of an algorithm portion and an encoded portion. The algorithm specifies the cryptographic hash function and encoding used for the digest; the encoded portion contains the encoded result of the hash function. A digest MUST be calculated for all properties except the digest itself which MUST be ignored during the calculation. The model SHOULD then be updated with the calculated digest.",
       "type": "fingerprint"
     },
-    "image": {
-      "caption": "Docker Image",
-      "description": "The Docker image that pertains to the class or object. See specific usage.",
-      "type": "string_t"
+    "discovery": {
+      "caption": "Discovery",
+      "description": "",
+      "type": "metric",
+      "is_array": true
     },
     "domain": {
       "caption": "Domain",
       "description": "The name of the domain. See specific usage.",
       "type": "string_t"
+    },
+    "energy_monitoring": {
+      "caption": "Energy Monitoring",
+      "description": "Tracks energy consumption during the operation of multi-agent systems, including training and inference, to identify inefficiencies and optimize resource usage.",
+      "type": "metric",
+      "is_array": true
+    },
+    "errors": {
+      "caption": "Errors",
+      "description": "",
+      "type": "metric",
+      "is_array": true
+    },
+    "events": {
+      "caption": "Events",
+      "description": "An event object that describes the event.",
+      "type": "object",
+      "is_array": true
     },
     "extension": {
       "caption": "Schema Extension",
@@ -256,6 +346,11 @@
       "description": "The hostname of an endpoint or a device.",
       "type": "hostname_t"
     },
+    "image": {
+      "caption": "Docker Image",
+      "description": "The Docker image that pertains to the class or object. See specific usage.",
+      "type": "string_t"
+    },
     "in": {
       "caption": "In",
       "description": "A location",
@@ -265,6 +360,11 @@
       "caption": "Input",
       "description": "A json input.",
       "type": "json_t"
+    },
+    "insights": {
+      "caption": "Insights",
+      "description": "Defines actionable insights derived from observability data for multi-agent applications, enabling improved performance, security, and collaboration.",
+      "type": "insights"
     },
     "interrupt_payload": {
       "caption": "Interrupt Payload",
@@ -287,6 +387,26 @@
       "type": "interrupts",
       "is_array": true
     },
+    "load_distribution": {
+      "caption": "Load distribution",
+      "description": "",
+      "type": "metric",
+      "is_array": true,
+      "enum": {
+        "number_of_active_agents": {
+          "caption": "Number of active agents"
+        },
+        "most_frequently_used_agents": {
+          "caption": "Most frequently used agents"
+        },
+        "agent_interaction_efficiency": {
+          "caption": "Agent-interaction: efficiency"
+        },
+        "agent_interaction_parallelism": {
+          "caption": "Agent-interaction: parallelism"
+        }
+      }
+    },
     "locator": {
       "caption": "Agent Locator",
       "description": "Locators provide actual artifact locators of an agent. For example, this can reference sources such as helm charts, docker images, binaries, and so on.",
@@ -298,10 +418,87 @@
       "type": "locator",
       "is_array": true
     },
+    "logs": {
+      "caption": "Logs",
+      "description": "An array of log objects.",
+      "type": "object",
+      "is_array": true
+    },
+    "melt_telemetry": {
+      "caption": "MELT Telemetry",
+      "description": "Captures metrics, events, logs, and traces to monitor the performance, interactions, and behavior of multi-agent systems.",
+      "type": "melt_telemetry"
+    },
+    "metric": {
+      "caption": "Metric",
+      "description": "",
+      "type": "metric"
+    },
+    "metrics": {
+      "caption": "Metrics",
+      "description": "Defines the key metrics used to evaluate system performance, cost, and other critical factors.",
+      "type": "metrics"
+    },
+    "multi_agent_collaboration": {
+      "caption": "Multi-agent Collaboration",
+      "description": "",
+      "type": "metric",
+      "is_array": true,
+      "enum": {
+        "most_active_agents": {
+          "caption": "Most active agents"
+        },
+        "agent_discovery_errors": {
+          "caption": "Agent discovery errors"
+        },
+        "task_delegation_accuracy": {
+          "caption": "Task delegation accuracy"
+        },
+        "load_distribution_accuracy": {
+          "caption": "Load distribution accuracy"
+        },
+        "Parallelism": {
+          "caption": "Parallelism"
+        }
+      }
+    },
     "name": {
       "caption": "Name",
       "description": "The name of the entity. See specific usage.",
       "type": "string_t"
+    },
+    "observability_level": {
+      "caption": "Observability Level",
+      "description": "The normalized caption of 'observability_level_id'.",
+      "type": "string_t"
+    },
+    "observability_level_id": {
+      "caption": "Observability Level ID",
+      "description": "Defines the granularity of information captured for multi-agent applications.",
+      "sibling": "observability_level",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Verbose",
+          "description": ""
+        },
+        "1": {
+          "caption": "Debug",
+          "description": ""
+        },
+        "2": {
+          "caption": "Info",
+          "description": ""
+        },
+        "3": {
+          "caption": "Warning",
+          "description": ""
+        },
+        "4": {
+          "caption": "Error",
+          "description": ""
+        }
+      }
     },
     "output": {
       "caption": "Output",
@@ -318,10 +515,25 @@
       "description": "The path that pertains to the class or object. See specific usage.",
       "type": "string_t"
     },
+    "performance": {
+      "caption": "Performance",
+      "description": "",
+      "type": "performance"
+    },
+    "planning_and_collaboration": {
+      "caption": "Planning and Collaboration",
+      "description": "Analyzes the coordination and planning efficiency among agents to optimize teamwork and resource allocation.",
+      "type": "object"
+    },
     "port": {
       "caption": "Port",
       "description": "The TCP/UDP port number associated with a connection. See specific usage.",
       "type": "port_t"
+    },
+    "predictions": {
+      "caption": "Predictions",
+      "description": "Provides forecasts and trend analysis based on historical observability data to support decision-making in multi-agent systems.",
+      "type": "object"
     },
     "protocol": {
       "caption": "ACP Endpoint",
@@ -332,6 +544,12 @@
       "caption": "HTTP Query String",
       "description": "The query portion of the URL. For example: the query portion of the URL <code>http://www.example.com/search?q=bad&sort=date</code> is <code>q=bad&sort=date</code>.",
       "type": "string_t"
+    },
+    "resiliency": {
+      "caption": "Resiliency",
+      "description": "Measures the ability of multi-agent systems to recover from failures and maintain operational continuity.",
+      "type": "metric",
+      "is_array": true
     },
     "resource_type": {
       "caption": "Resource Type",
@@ -348,10 +566,21 @@
       "description": "An instance of an OpenAPI schema object, formatted as per the OpenAPI specs: <a target='_blank' href='https://spec.openapis.org/oas/v3.1.1.html#schema-object' >Schema Object</a>.",
       "type": "json_t"
     },
+    "risk_assessment": {
+      "caption": "Risk Assessment",
+      "description": "Evaluates potential risks and vulnerabilities in multi-agent workflows, enabling mitigation strategies.",
+      "type": "object"
+    },
     "scheme": {
       "caption": "Scheme",
       "description": "The scheme portion of the URL. For example: <code>http</code>, <code>https</code>, <code>ftp</code>, or <code>sftp</code>.",
       "type": "string_t"
+    },
+    "security_and_compliance": {
+      "caption": "Security and Compliance",
+      "description": "",
+      "type": "metric",
+      "is_array": true
     },
     "size": {
       "caption": "Size",
@@ -390,6 +619,46 @@
       "description": "The subdomain portion of the URL. For example: <code>sub</code> in <code>https://sub.example.com</code> or <code>sub2.sub1</code> in <code>https://sub2.sub1.example.com</code>.",
       "type": "string_t"
     },
+    "success": {
+      "caption": "Success",
+      "description": "Evaluates the achievement of goals and objectives within multi-agent workflows, providing metrics for effectiveness.",
+      "type": "metric", 
+      "is_array": true
+    },
+    "system_level": {
+      "caption": "System Level Metrics",
+      "description": "",
+      "type": "metric",
+      "is_array": true,
+      "enum": {
+        "most_frequent_agent_interactions": {
+          "caption": "Most frequent agent-to-agent interactions."
+        },
+        "most_failing_agents": {
+          "caption": "Most failing agents."
+        },
+        "transfer_timing_accuracy": {
+          "caption": "Transfer timing accuracy."
+        },
+        "connection_reliability": {
+          "caption": "Connection Reliability."
+        },
+        "agent_interpretation_score": {
+          "caption": "Agent Interpretation Score (whether data exchanged between agents is in correct format)."
+        },
+        "deprecated_or_inactive_agents_count": {
+          "caption": "Number of deprecated or inactive agents."
+        },
+        "average_fault_detection_time": {
+          "caption": "Average time needed to detect faulty agent."
+        }
+      }
+    },
+    "sustainability": {
+      "caption": "Sustainability",
+      "description": "Defines sustainability metrics and tools for multi-agent applications, focusing on energy efficiency and environmental impact.",
+      "type": "sustainability"
+    },
     "thread_state": {
       "caption": "ThreadState",
       "description": "This describes the format of ThreadState. Cannot be specified if `threads` capability is false. If not specified, when `threads` capability is true, then the API to retrieve ThreadState from a Thread or a Run is not available. This object contains an instance of an OpenAPI schema object, formatted as per the OpenAPI specs: <a target='_blank' href='https://spec.openapis.org/oas/v3.1.1.html#schema-object' >Schema Object</a>.",
@@ -399,6 +668,12 @@
       "caption": "Threads",
       "description": "This is `true` if the agent supports run threads. If this is `false`, then the threads tagged with `Threads` are not available. If missing, it means `false`.",
       "type": "boolean_t"
+    },
+    "traces": {
+      "caption": "Traces",
+      "description": "An array of trace objects.",
+      "type": "object",
+      "is_array": true
     },
     "type": {
       "caption": "Type",
@@ -452,6 +727,11 @@
       "caption": "URL",
       "description": "The URL object that pertains to the class or object. See specific usage.",
       "type": "url"
+    },
+    "unit_of_measurement": {
+      "caption": "Unit of Measurement",
+      "description": "The unit in which the metric is measured (e.g., 'seconds', 'bytes', 'percentage').",
+      "type": "string_t"
     },
     "url_string": {
       "caption": "URL String",

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -90,7 +90,7 @@
     },
     "carbon_footprint_analysis": {
       "caption": "Carbon Footprint Analysis",
-      "description": "Evaluates the greenhouse gas emissions associated with the workflows of multi-agent systems, enabling strategies for reducing environmental impact.",
+      "description": "Evaluates the greenhouse gas emissions associated with the workflows of multi-agent systems to enable strategies for reducing environmental impact.",
       "type": "metric",
       "is_array": true
     },
@@ -363,7 +363,7 @@
     },
     "insights": {
       "caption": "Insights",
-      "description": "Defines actionable insights derived from observability data for multi-agent applications, enabling improved performance, security, and collaboration.",
+      "description": "Defines actionable insights derived from observability data for multi-agent applications to enable improved performance, security, and collaboration.",
       "type": "insights"
     },
     "interrupt_payload": {
@@ -394,16 +394,16 @@
       "is_array": true,
       "enum": {
         "number_of_active_agents": {
-          "caption": "Number of active agents"
+          "caption": "Number of active agents."
         },
         "most_frequently_used_agents": {
-          "caption": "Most frequently used agents"
+          "caption": "Most frequently used agents."
         },
         "agent_interaction_efficiency": {
-          "caption": "Agent-interaction: efficiency"
+          "caption": "Agent-interaction: efficiency."
         },
         "agent_interaction_parallelism": {
-          "caption": "Agent-interaction: parallelism"
+          "caption": "Agent-interaction: parallelism."
         }
       }
     },
@@ -446,16 +446,16 @@
       "is_array": true,
       "enum": {
         "most_active_agents": {
-          "caption": "Most active agents"
+          "caption": "Most active agents."
         },
         "agent_discovery_errors": {
-          "caption": "Agent discovery errors"
+          "caption": "Agent discovery errors."
         },
         "task_delegation_accuracy": {
-          "caption": "Task delegation accuracy"
+          "caption": "Task delegation accuracy."
         },
         "load_distribution_accuracy": {
-          "caption": "Load distribution accuracy"
+          "caption": "Load distribution accuracy."
         },
         "Parallelism": {
           "caption": "Parallelism"
@@ -568,7 +568,7 @@
     },
     "risk_assessment": {
       "caption": "Risk Assessment",
-      "description": "Evaluates potential risks and vulnerabilities in multi-agent workflows, enabling mitigation strategies.",
+      "description": "Evaluates potential risks and vulnerabilities in multi-agent workflows and therefre enabling mitigation strategies.",
       "type": "object"
     },
     "scheme": {
@@ -621,7 +621,7 @@
     },
     "success": {
       "caption": "Success",
-      "description": "Evaluates the achievement of goals and objectives within multi-agent workflows, providing metrics for effectiveness.",
+      "description": "Evaluates the achievement of goals and objectives within multi-agent workflows to provide metrics for effectiveness.",
       "type": "metric", 
       "is_array": true
     },
@@ -730,7 +730,7 @@
     },
     "unit_of_measurement": {
       "caption": "Unit of Measurement",
-      "description": "The unit in which the metric is measured (e.g., 'seconds', 'bytes', 'percentage').",
+      "description": "The unit in which the metric is measured (for example, 'seconds', 'bytes', or 'percentage').",
       "type": "string_t"
     },
     "url_string": {

--- a/schema/objects/insights.json
+++ b/schema/objects/insights.json
@@ -9,46 +9,46 @@
       "description": "Measures the ability of multi-agent systems to recover from failures and maintain operational continuity.",
       "enum": {
         "top_failure_points": {
-          "caption": "Top failure points in agent execution"
+          "caption": "Top failure points in agent execution."
         },
         "error_frequency_per_agent": {
-          "caption": "Error frequency count per agent"
+          "caption": "Error frequency count per agent."
         },
         "general_uptime": {
-          "caption": "General uptime and availability measure of the agent"
+          "caption": "General uptime and availability measure of the agent."
         },
         "recovery_rate": {
-          "caption": "Recovery rate from failures"
+          "caption": "Recovery rate from failures."
         },
         "agent_recovery_rate": {
-          "caption": "Recovery rate of an agent in terms of any failures"
+          "caption": "Recovery rate of an agent in case of failures."
         },
         "failed_tool_calls": {
-          "caption": "Tracks failed tool/API calls"
+          "caption": "Tracks failed tool or API calls."
         }
       }
     },
     "security_and_compliance": {
       "caption": "Security and Compliance",
-      "description": "Tracks adherence to security standards and regulatory compliance, ensuring the safety and integrity of multi-agent systems.",
+      "description": "Tracks adherence to security standards and regulatory compliance and ensuring the safety and integrity of multi-agent systems.",
       "enum": {
         "data_compliance_adherence": {
-          "caption": "Data compliance adherence"
+          "caption": "Data compliance adherence."
         }
       }
     },
     "success": {
       "caption": "Success",
-      "description": "Evaluates the achievement of goals and objectives within multi-agent workflows, providing metrics for effectiveness.",
+      "description": "Evaluates the achievement of goals and objectives within multi-agent workflows providing metrics for effectiveness.",
       "enum": {
         "completion_rate": {
-          "caption": "Completion rate of tasks or objectives"
+          "caption": "Completion rate of tasks or objectives."
         },
         "success_rate": {
-          "caption": "Success rate of agent interactions"
+          "caption": "Success rate of agent interactions."
         },
         "task_completion_time": {
-          "caption": "Average time taken to complete tasks"
+          "caption": "Average time taken to complete tasks."
         }
       }
     },
@@ -57,19 +57,19 @@
       "description": "Analyzes the coordination and planning efficiency among agents to optimize teamwork and resource allocation.",
       "enum": {
         "task_delegation_accuracy": {
-          "caption": "Task delegation accuracy"
+          "caption": "Task delegation accuracy."
         },
         "load_distribution_accuracy": {
-          "caption": "Load distribution accuracy"
+          "caption": "Load distribution accuracy."
         },
         "parallelism": {
-          "caption": "Degree of parallelism in task execution"
+          "caption": "Degree of parallelism in task execution."
         }
       }
     },
     "anomaly_detection": {
       "caption": "Anomaly Detection",
-      "description": "Identifies unusual patterns or behaviors in multi-agent systems, enabling proactive issue resolution."
+      "description": "Identifies unusual patterns or behaviors in multi-agent systems enabling proactive issue resolution."
     },
     "alerting": {
       "caption": "Alerting",
@@ -84,19 +84,19 @@
       "description": "Monitors and analyzes the financial expenditure associated with multi-agent operations to ensure cost efficiency.",
       "enum": {
         "cost_per_run": {
-          "caption": "Cost per run of the multi-agent system"
+          "caption": "Cost per run of the multi-agent system."
         },
         "cost_per_task": {
-          "caption": "Cost per task executed by the agents"
+          "caption": "Cost per task executed by the agents."
         },
         "cost_per_agent": {
-          "caption": "Cost associated with each agent"
+          "caption": "Cost associated with each agent."
         }
       }
     },
     "risk_assessment": {
       "caption": "Risk Assessment",
-      "description": "Evaluates potential risks and vulnerabilities in multi-agent workflows, enabling mitigation strategies."
+      "description": "Evaluates potential risks and vulnerabilities in multi-agent workflows to enable mitigation strategies."
     }
   },
   "references": [

--- a/schema/objects/insights.json
+++ b/schema/objects/insights.json
@@ -1,0 +1,108 @@
+{
+  "caption": "Insights",
+  "description": "Defines actionable insights derived from observability data for multi-agent applications, enabling improved performance, security, and collaboration.",
+  "extends": "object",
+  "name": "insights",
+  "attributes": {
+    "resiliency": {
+      "caption": "Resiliency",
+      "description": "Measures the ability of multi-agent systems to recover from failures and maintain operational continuity.",
+      "enum": {
+        "top_failure_points": {
+          "caption": "Top failure points in agent execution"
+        },
+        "error_frequency_per_agent": {
+          "caption": "Error frequency count per agent"
+        },
+        "general_uptime": {
+          "caption": "General uptime and availability measure of the agent"
+        },
+        "recovery_rate": {
+          "caption": "Recovery rate from failures"
+        },
+        "agent_recovery_rate": {
+          "caption": "Recovery rate of an agent in terms of any failures"
+        },
+        "failed_tool_calls": {
+          "caption": "Tracks failed tool/API calls"
+        }
+      }
+    },
+    "security_and_compliance": {
+      "caption": "Security and Compliance",
+      "description": "Tracks adherence to security standards and regulatory compliance, ensuring the safety and integrity of multi-agent systems.",
+      "enum": {
+        "data_compliance_adherence": {
+          "caption": "Data compliance adherence"
+        }
+      }
+    },
+    "success": {
+      "caption": "Success",
+      "description": "Evaluates the achievement of goals and objectives within multi-agent workflows, providing metrics for effectiveness.",
+      "enum": {
+        "completion_rate": {
+          "caption": "Completion rate of tasks or objectives"
+        },
+        "success_rate": {
+          "caption": "Success rate of agent interactions"
+        },
+        "task_completion_time": {
+          "caption": "Average time taken to complete tasks"
+        }
+      }
+    },
+    "planning_and_collaboration": {
+      "caption": "Planning and Collaboration",
+      "description": "Analyzes the coordination and planning efficiency among agents to optimize teamwork and resource allocation.",
+      "enum": {
+        "task_delegation_accuracy": {
+          "caption": "Task delegation accuracy"
+        },
+        "load_distribution_accuracy": {
+          "caption": "Load distribution accuracy"
+        },
+        "parallelism": {
+          "caption": "Degree of parallelism in task execution"
+        }
+      }
+    },
+    "anomaly_detection": {
+      "caption": "Anomaly Detection",
+      "description": "Identifies unusual patterns or behaviors in multi-agent systems, enabling proactive issue resolution."
+    },
+    "alerting": {
+      "caption": "Alerting",
+      "description": "Generates notifications or warnings based on predefined thresholds or detected anomalies in multi-agent operations."
+    },
+    "predictions": {
+      "caption": "Predictions",
+      "description": "Provides forecasts and trend analysis based on historical observability data to support decision-making in multi-agent systems."
+    },
+    "cost_tracking": {
+      "caption": "Cost Tracking",
+      "description": "Monitors and analyzes the financial expenditure associated with multi-agent operations to ensure cost efficiency.",
+      "enum": {
+        "cost_per_run": {
+          "caption": "Cost per run of the multi-agent system"
+        },
+        "cost_per_task": {
+          "caption": "Cost per task executed by the agents"
+        },
+        "cost_per_agent": {
+          "caption": "Cost associated with each agent"
+        }
+      }
+    },
+    "risk_assessment": {
+      "caption": "Risk Assessment",
+      "description": "Evaluates potential risks and vulnerabilities in multi-agent workflows, enabling mitigation strategies."
+    }
+  },
+  "references": [
+    {
+      "description": "OpenTelemetry Specification",
+      "url": "https://opentelemetry.io/docs/specs/otel/metrics/"
+    }
+  ]
+}

--- a/schema/objects/melt_telemetry.json
+++ b/schema/objects/melt_telemetry.json
@@ -1,0 +1,46 @@
+{
+  "caption": "MELT telemetry",
+  "description": "Defines the telemetry data structure for metrics, events, logs, and traces.",
+  "extends": "object",
+  "name": "melt_telemetry",
+  "attributes": {
+    "metrics": {
+      "caption": "Metrics",
+      "requirement": "required",
+      "description": "Quantitative measurements that provide insights into system performance and behavior."
+    },
+    "events": {
+      "caption": "Events",
+      "requirement": "required",
+      "description": "Discrete occurrences or actions captured within the system, such as user interactions or system changes."
+    },
+    "logs": {
+      "caption": "Logs",
+      "requirement": "required",
+      "description": "Recorded messages or data entries that provide detailed information about system operations.",
+      "references": [
+        {
+          "description": "OpenTelemetry Specification",
+          "url": "https://opentelemetry.io/docs/specs/otel/logs/data-model/#log-and-event-record-definition"
+        }
+      ]
+    },
+    "traces": {
+      "caption": "Traces",
+      "requirement": "required",
+      "description": "Distributed traces that represent the flow of requests across services in the system.",
+      "references": [
+        {
+          "description": "OpenTelemetry Specification",
+          "url": "https://opentelemetry.io/docs/specs/otel/trace/api/"
+        }
+      ]
+    }
+  },
+  "references": [
+    {
+      "description": "OpenTelemetry Specification",
+      "url": "https://opentelemetry.io/docs/specs/otel/"
+    }
+  ]
+}

--- a/schema/objects/metric.json
+++ b/schema/objects/metric.json
@@ -7,12 +7,12 @@
     "name": {
       "caption": "Metric Name",
       "requirement": "required",
-      "description": "The unique name of the metric, identifying the specific measurement being captured (e.g., 'CPU Usage', 'Response Time')."
+      "description": "The unique name of the metric, identifying the specific measurement being captured (for example, 'CPU Usage' or 'Response Time')."
     },
     "attributes": {
       "caption": "Attributes",
       "requirement": "recommended",
-      "description": "Additional metadata or dimensions associated with the metric, such as tags or labels (e.g., 'region', 'agent_id')."
+      "description": "Additional metadata or dimensions associated with the metric, such as tags or labels (for example, 'region' or 'agent_id')."
     },
     "type": {
       "caption": "Type",
@@ -22,7 +22,7 @@
     "unit_of_measurement": {
       "caption": "Unit of Measurement",
       "requirement": "required",
-      "description": "The unit in which the metric value is reported. Follows the format described by <a target='_blank' href='http://unitsofmeasure.org/ucum.html'>UCUM (Unified Code for Units of Measure)</a> (e.g., 'seconds', 'bytes', 'percentage').",
+      "description": "The unit in which the metric value is reported. Follows the format described by <a target='_blank' href='http://unitsofmeasure.org/ucum.html'>UCUM (Unified Code for Units of Measure)</a> (for example, 'seconds', 'bytes', or 'percentage').",
       "references": [
         {
           "description": "UCUM Specification",

--- a/schema/objects/metric.json
+++ b/schema/objects/metric.json
@@ -1,0 +1,51 @@
+{
+  "caption": "Metric",
+  "description": "Defines a metric applicable to an agent, capturing quantitative data for analysis and monitoring.",
+  "extends": "object",
+  "name": "metric",
+  "attributes": {
+    "name": {
+      "caption": "Metric Name",
+      "requirement": "required",
+      "description": "The unique name of the metric, identifying the specific measurement being captured (e.g., 'CPU Usage', 'Response Time')."
+    },
+    "attributes": {
+      "caption": "Attributes",
+      "requirement": "recommended",
+      "description": "Additional metadata or dimensions associated with the metric, such as tags or labels (e.g., 'region', 'agent_id')."
+    },
+    "type": {
+      "caption": "Type",
+      "requirement": "required",
+      "description": "Specifies the type of metric, such as 'counter', 'gauge', or 'histogram', which determines how the metric data is aggregated and interpreted."
+    },
+    "unit_of_measurement": {
+      "caption": "Unit of Measurement",
+      "requirement": "required",
+      "description": "The unit in which the metric value is reported. Follows the format described by <a target='_blank' href='http://unitsofmeasure.org/ucum.html'>UCUM (Unified Code for Units of Measure)</a> (e.g., 'seconds', 'bytes', 'percentage').",
+      "references": [
+        {
+          "description": "UCUM Specification",
+          "url": "http://unitsofmeasure.org/ucum.html"
+        }
+      ]
+    },
+    "data_points": {
+      "caption": "Data Points",
+      "requirement": "required",
+      "description": "The actual data points collected for the metric, which can be a single value or a collection of values over time.",
+      "references": [
+        {
+          "description": "OpenTelemetry Specification",
+          "url": "https://opentelemetry.io/docs/specs/otel/metrics/data-model/#point-kinds"
+        }
+      ]
+    }
+  },
+  "references": [
+    {
+      "description": "OpenTelemetry Specification",
+      "url": "https://opentelemetry.io/docs/specs/otel/metrics/data-model/#model-details"
+    }
+  ]
+}

--- a/schema/objects/metrics.json
+++ b/schema/objects/metrics.json
@@ -25,7 +25,7 @@
       "description": "Tracks adherence to security standards and regulatory compliance requirements.",
       "enum": {
         "number_of_unauthorized_calls_blocked_per_agent": {
-          "caption": "Number of unauthorised calls blocked per agent"
+          "caption": "Number of unauthorized calls blocked per agent."
         }
       }
     }

--- a/schema/objects/metrics.json
+++ b/schema/objects/metrics.json
@@ -1,0 +1,39 @@
+{
+  "caption": "Metrics",
+  "description": "Defines the key metrics used to evaluate system performance, cost, and other critical factors.",
+  "extends": "object",
+  "name": "metrics",
+  "attributes": {
+    "cost": {
+      "caption": "Cost",
+      "description": "Represents the financial or resource expenditure associated with system operations."
+    },
+    "performance": {
+      "caption": "Performance",
+      "description": "Measures the efficiency and speed of the system in executing tasks and handling workloads."
+    },
+    "multi_agent_collaboration": {
+      "caption": "Multi-agent Collaboration",
+      "description": "Evaluates the effectiveness of interactions and coordination between multiple agents in the system."
+    },
+    "sustainability": {
+      "caption": "Sustainability",
+      "description": "Assesses the environmental and resource impact of the system's operations."
+    },
+    "security_and_compliance": {
+      "caption": "Security and Compliance",
+      "description": "Tracks adherence to security standards and regulatory compliance requirements.",
+      "enum": {
+        "number_of_unauthorized_calls_blocked_per_agent": {
+          "caption": "Number of unauthorised calls blocked per agent"
+        }
+      }
+    }
+  },
+  "references": [
+    {
+      "description": "OpenTelemetry Specification",
+      "url": "https://opentelemetry.io/docs/specs/otel/metrics/"
+    }
+  ]
+}

--- a/schema/objects/observability.json
+++ b/schema/objects/observability.json
@@ -1,6 +1,6 @@
 {
   "caption": "Observability",
-  "description": "Defines the schema for observing and monitoring multi-agent applications, enabling insights into their behavior, performance, and interactions.",
+  "description": "Defines the schema for observing and monitoring multi-agent applications to enable insights into their behavior, performance, and interactions.",
   "extends": "object",
   "name": "observability",
   "attributes": {

--- a/schema/objects/observability.json
+++ b/schema/objects/observability.json
@@ -1,0 +1,30 @@
+{
+  "caption": "Observability",
+  "description": "Defines the schema for observing and monitoring multi-agent applications, enabling insights into their behavior, performance, and interactions.",
+  "extends": "object",
+  "name": "observability",
+  "attributes": {
+    "melt_telemetry": {
+      "caption": "MELT Telemetry",
+      "description": "Captures metrics, events, logs, and traces to monitor the performance, interactions, and behavior of multi-agent systems."
+    },
+    "insights": {
+      "caption": "Insights",
+      "description": "Provides actionable intelligence derived from telemetry data to optimize multi-agent collaboration and system performance."
+    },
+    "observability_level": {
+      "caption": "Level of observability",
+      "description": "The normalized caption of 'observability_level_id'."
+    },
+    "observability_level_id": {
+      "caption": "Level of observability",
+      "description": "Defines the granularity of information captured for multi-agent applications."
+    }
+  },
+  "references": [
+    {
+      "description": "OpenTelemetry Specification",
+      "url": "https://opentelemetry.io/docs/specs/otel/"
+    }
+  ]
+}

--- a/schema/objects/performance.json
+++ b/schema/objects/performance.json
@@ -1,0 +1,34 @@
+{
+  "caption": "Performance",
+  "description": "Defines performance metrics and attributes for multi-agent applications, focusing on load distribution, controllability, discovery, error handling, and system-level efficiency.",
+  "extends": "object",
+  "name": "performance",
+  "attributes": {
+    "load_distribution": {
+      "caption": "Load Distribution",
+      "description": "Measures how computational and operational workloads are distributed across agents to ensure balanced resource utilization and prevent bottlenecks."
+    },
+    "controllability": {
+      "caption": "Controllability",
+      "description": "Evaluates the ability to manage and control the behavior of agents in the system, ensuring predictable and efficient operations."
+    },
+    "discovery": {
+      "caption": "Discovery",
+      "description": "Tracks the efficiency and accuracy of discovering agents, services, or resources within the multi-agent system."
+    },
+    "errors": {
+      "caption": "Errors",
+      "description": "Monitors the frequency, types, and impact of errors encountered during multi-agent operations, enabling proactive issue resolution."
+    },
+    "system_level": {
+      "caption": "System-Level",
+      "description": "Analyzes the overall performance of the multi-agent system, including throughput, latency, and scalability metrics."
+    }
+  },
+  "references": [
+    {
+      "description": "OpenTelemetry Specification",
+      "url": "https://opentelemetry.io/docs/specs/otel/metrics/"
+    }
+  ]
+}

--- a/schema/objects/sustainability.json
+++ b/schema/objects/sustainability.json
@@ -1,0 +1,16 @@
+{
+  "caption": "Sustainability",
+  "description": "Defines sustainability metrics and tools for multi-agent applications, focusing on energy efficiency and environmental impact.",
+  "extends": "object",
+  "name": "sustainability",
+  "attributes": {
+    "energy_monitoring": {
+      "caption": "Energy Monitoring",
+      "description": "Tracks energy consumption during the operation of multi-agent systems, including training and inference, to identify inefficiencies and optimize resource usage."
+    },
+    "carbon_footprint_analysis": {
+      "caption": "Carbon Footprint Analysis",
+      "description": "Evaluates the greenhouse gas emissions associated with the workflows of multi-agent systems, enabling strategies for reducing environmental impact."
+    }
+  }
+}

--- a/schema/objects/sustainability.json
+++ b/schema/objects/sustainability.json
@@ -10,7 +10,7 @@
     },
     "carbon_footprint_analysis": {
       "caption": "Carbon Footprint Analysis",
-      "description": "Evaluates the greenhouse gas emissions associated with the workflows of multi-agent systems, enabling strategies for reducing environmental impact."
+      "description": "Evaluates the greenhouse gas emissions associated with the workflows of multi-agent systems to enable strategies for reducing environmental impact."
     }
   }
 }


### PR DESCRIPTION
Adds initial agent and multi-agentic application observability schema to the OASF. 

Signed-off-by: Laszlo Gecse [lgecse@cisco.com](mailto:lgecse@cisco.com)