### PR TITLE
feat: object enum

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -316,15 +316,8 @@
     "framework_config": {
       "caption": "Agentic Framework Config",
       "description": "Config for an agent of an agentic framework.",
-      "type": "object",
-      "enum": {
-        "llamaindex_config": {
-          "caption": "Llamaindex Config"
-        },
-        "langgraph_config": {
-          "caption": "LangGraph Config"
-        }
-      }
+      "type": "agentic_framework_config",
+      "is_enum": true
     },
     "framework_type": {
       "caption": "Framework Type",

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -258,19 +258,9 @@
     "deployment_options": {
       "caption": "Deployment Options",
       "description": "List of possible methods to instantiate or consume the agent.  Any of the available option could be used. Every option could be associated with a unique name within this agent. If present, when another manifest refers to this manifest, it can also select the preferred deployment option.",
-      "type": "object",
-      "is_array": true,
-      "enum": {
-        "source_code_deployment": {
-          "caption": "Source Code Deployment"
-        },
-        "agent_deployment": {
-          "caption": "Agent Deployment"
-        },
-        "docker_deployment": {
-          "caption": "Docker Deployment"
-        }
-      }
+      "type": "deployment_option",
+      "is_enum": true,
+      "is_array": true
     },
     "digest": {
       "caption": "Digest",

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -310,17 +310,17 @@
       "caption": "Schema Extension",
       "description": "Extension model that describes agents and its capabilities more in depth.",
       "type": "class_t",
-      "class_path": "features",
-      "class_name": "base_feature",
-      "class_caption": "Extension"
+      "class_type": "base_feature",
+      "path": "features",
+      "is_enum": true
     },
     "extensions": {
       "caption": "Schema Extensions",
       "description": "List of extension models that describe this agent and its capabilities more in depth.",
       "type": "class_t",
-      "class_path": "features",
-      "class_name": "base_feature",
-      "class_caption": "Extension",
+      "class_type": "base_feature",
+      "path": "features",
+      "is_enum": true,
       "is_array": true
     },
     "framework_config": {
@@ -576,17 +576,17 @@
       "caption": "Skill",
       "description": "A skill that apply to an agent.",
       "type": "class_t",
-      "class_path": "classes/base_skill",
-      "class_name": "base_skill",
-      "class_caption": "Skill"
+      "class_type": "base_skill",
+      "path": "skills",
+      "is_enum": true
     },
     "skills": {
       "caption": "Skills",
       "description": "Skills that apply to an agent.",
       "type": "class_t",
-      "class_path": "skills",
-      "class_name": "base_skill",
-      "class_caption": "Skill",
+      "class_type": "base_skill",
+      "path": "skills",
+      "is_enum": true,
       "is_array": true
     },
     "specs": {
@@ -741,7 +741,7 @@
       },
       "class_t": {
         "caption": "Class",
-        "description": "Name of the class linked to the object.",
+        "description": "Name of the class associated to an attribute.",
         "type": "string_t",
         "type_name": "String"
       },

--- a/schema/metaschema/dictionary-attribute.schema.json
+++ b/schema/metaschema/dictionary-attribute.schema.json
@@ -35,6 +35,10 @@
             "type": "boolean",
             "description": "A flag used when the attribute represents an array of values rather than a single value."
         },
+        "is_enum": {
+            "type": "boolean",
+            "description": "A flag used when the attribute represents a limited scope of objects/classes, extending a parent object/class rather than a single value. Can be applied only for object and class types."
+        },
         "suppress_checks": {
           "type": "array",
           "items": {

--- a/schema/objects/agent_deployment.json
+++ b/schema/objects/agent_deployment.json
@@ -7,7 +7,7 @@
     "deployment_options": {
       "caption": "Deployment Options",
       "description": "List of possible methods to instantiate or consume the agent.  Any of the available option could be used. Every option could be associated with a unique name within this agent. If present, when another manifest refers to this manifest, it can also select the preferred deployment option.",
-      "requirement": "optional"
+      "requirement": "required"
     },
     "dependencies": {
       "caption": "Agent Dependencies",

--- a/schema/objects/agentic_framework_config.json
+++ b/schema/objects/agentic_framework_config.json
@@ -1,0 +1,7 @@
+{
+  "caption": "Agentic Framework Config",
+  "description": "Describes an agent deployment config for an agentic framework.",
+  "extends": "object",
+  "name": "agentic_framework_config",
+  "attributes": {}
+}

--- a/schema/objects/deployment_option.json
+++ b/schema/objects/deployment_option.json
@@ -1,0 +1,7 @@
+{
+  "caption": "Deployment Option",
+  "description": "Describes a deployment option for an agent.",
+  "extends": "object",
+  "name": "deployment_option",
+  "attributes": {}
+}

--- a/schema/objects/docker_deployment.json
+++ b/schema/objects/docker_deployment.json
@@ -1,7 +1,7 @@
 {
   "caption": "Docker Deployment",
   "description": "Describes the docker deployment for this agent.",
-  "extends": "object",
+  "extends": "deployment_option",
   "name": "docker_deployment",
   "attributes": {
     "type": {

--- a/schema/objects/langgraph_config.json
+++ b/schema/objects/langgraph_config.json
@@ -1,7 +1,7 @@
 {
   "caption": "LangGraph Config",
   "description": "Describes an agent deployment config for the LangGraph framework.",
-  "extends": "object",
+  "extends": "agentic_framework_config",
   "name": "langgraph_config",
   "attributes": {
     "framework_type": {

--- a/schema/objects/llamaindex_config.json
+++ b/schema/objects/llamaindex_config.json
@@ -1,7 +1,7 @@
 {
   "caption": "Llamaindex Config",
   "description": "Describes an agent deployment config for the Llamaindex framework.",
-  "extends": "object",
+  "extends": "agentic_framework_config",
   "name": "llamaindex_config",
   "attributes": {
     "framework_type": {

--- a/schema/objects/remote_service_deployment.json
+++ b/schema/objects/remote_service_deployment.json
@@ -1,7 +1,7 @@
 {
   "caption": "Remote Service Deployment",
   "description": "Describes the network endpoint where the agent is available.",
-  "extends": "object",
+  "extends": "deployment_option",
   "name": "remote_service_deployment",
   "attributes": {
     "type": {

--- a/schema/objects/source_code_deployment.json
+++ b/schema/objects/source_code_deployment.json
@@ -1,7 +1,7 @@
 {
   "caption": "Source Code Deployment",
   "description": "Describes the source code where the agent is available. It specifies also the type of deployer that it supports.",
-  "extends": "object",
+  "extends": "deployment_option",
   "name": "source_code_deployment",
   "attributes": {
     "type": {

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -335,15 +335,19 @@ defmodule Schema.Generator do
   defp generate_array({name, field} = attribute) do
     n = random(@max_array_size)
 
-    case field[:type] do
-      "object_t" ->
-        generate_objects(n, attribute)
+    if n > 0 do
+      case field[:type] do
+        "object_t" ->
+          generate_objects(n, attribute)
 
-      "class_t" ->
-        generate_classes(n, attribute)
+        "class_t" ->
+          generate_classes(n, attribute)
 
-      type ->
-        Enum.map(1..n, fn _ -> generate_data(name, type, field) end)
+        type ->
+          Enum.map(1..n, fn _ -> generate_data(name, type, field) end)
+      end
+    else
+      []
     end
   end
 

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -208,6 +208,10 @@ defmodule Schema.Generator do
           "object_t" ->
             generate_object(field[:requirement], name, attribute, map)
 
+          "class_t" ->
+            get_valid_class(field)
+            |> generate_sample_class(Process.get(:profiles))
+
           nil ->
             Logger.warning("Invalid type name: #{name}")
             map

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -95,7 +95,23 @@ defmodule Schema.Utils do
   def update_objects(objects, dictionary) do
     Enum.into(objects, %{}, fn {name, object} ->
       links = object_links(dictionary, Atom.to_string(name))
-      {name, Map.put(object, :_links, links)}
+
+      children =
+        find_children(objects, Atom.to_string(name))
+        |> Enum.map(fn child ->
+          child
+          |> Map.put(:object_name, child[:caption])
+          |> Map.put(:type, Atom.to_string(:object_t))
+          |> Map.put(:object_type, child[:name])
+        end)
+        |> Enum.into(%{}, fn child ->
+          {child.name, child}
+        end)
+
+      object
+      |> Map.put(:_links, links)
+      |> Map.put(:_children, children)
+      |> (&{name, &1}).()
     end)
   end
 

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -493,4 +493,16 @@ defmodule Schema.Utils do
       {nil, nil}
     end
   end
+
+  @spec find_children(map(), String.t()) :: [map()]
+  def find_children(map, parent_name) do
+    map
+    |> Enum.filter(fn {_key, elem} ->
+      Map.has_key?(elem, :extends) && elem[:extends] == parent_name
+    end)
+    |> Enum.map(fn {_key, elem} -> elem end)
+    |> Enum.flat_map(fn elem ->
+      [elem | find_children(map, elem[:name])]
+    end)
+  end
 end

--- a/server/lib/schema_web/templates/page/object.html.eex
+++ b/server/lib/schema_web/templates/page/object.html.eex
@@ -77,7 +77,11 @@ SPDX-License-Identifier: Apache-2.0
   </div>
 </div>
 
+<%= if Enum.empty?(@data[:attributes]) do %>
+<div></div>
+<% else %>
 <div class="mt-4">
+  <h5>Attributes</h5>
   <table id="data-table" class="table table-bordered sortable">
     <thead>
       <tr class="thead-color">
@@ -101,6 +105,35 @@ SPDX-License-Identifier: Apache-2.0
     </tbody>
   </table>
 </div>
+<% end %>
+
+<%= if Enum.empty?(@data[:_children]) do %>
+<div></div>
+<% else %>
+<div class="mt-4">
+  <h5>Children objects</h5>
+  <table id="data-table" class="table table-bordered sortable">
+    <thead>
+      <tr class="thead-color">
+        <th style="width: 12%">Caption</th>
+        <th style="width: 12%">Name</th>
+        <th style="width: 12%">Type</th>
+        <th style="width: 34%">Description</th>
+      </tr>
+    </thead>
+    <tbody class="searchable">
+      <%= for {key, field} <- @data[:_children] do %>
+      <tr class="<%= field_classes(field)%>">
+        <td class="name"><%= raw format_attribute_caption(@conn, key, field) %></td>
+        <td data-toggle="tooltip" title="<%= format_object_attribute_source(@data[:key], field) %>"><%= raw format_attribute_name(key) %></td>
+        <td class="extensions"><%= raw format_type(@conn, field) %></td>
+        <td><%= raw format_desc(key, field) %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<% end %>
 
 <% links = @data[:_links] %>
 <%= if Enum.empty?(links) do %>

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -536,10 +536,10 @@ defmodule SchemaWeb.PageView do
           end
 
         "class_t" ->
-          class = Map.get(field, :class_path)
+          class = Map.get(field, :path)
           class_path = SchemaWeb.Router.Helpers.static_path(conn, "/#{class}")
 
-          case Map.get(field, :class_caption) do
+          case Map.get(field, :caption) do
             nil ->
               "<a href='#{class_path}'>#{format_type(conn, class)}</a>"
 
@@ -548,7 +548,7 @@ defmodule SchemaWeb.PageView do
           end
 
         _type ->
-          Map.get(field, :type_name) || ""
+          Map.get(field, :type_name) || Map.get(field, :name) || ""
       end
 
     array? = Map.get(field, :is_array)

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -634,6 +634,7 @@ defmodule SchemaWeb.PageView do
   defp append_source_references(html, prefix_html, obj) do
     source = obj[:source]
     references = obj[:references]
+    enum = obj[:is_enum]
 
     source_html =
       if source != nil do
@@ -653,8 +654,38 @@ defmodule SchemaWeb.PageView do
         ""
       end
 
-    if source_html != "" or refs_html != "" do
-      [html, prefix_html, "<dd>", source_html, refs_html, "</dd>"]
+    options_html =
+      case obj[:type] do
+        "object_t" ->
+          children = Schema.Utils.find_children(Schema.objects(), obj[:object_type])
+
+          if children != nil do
+            [
+              "<dt>Options<dd class=\"ml-3\">",
+              Enum.map(children, fn child ->
+                [
+                  "<div>",
+                  "<a href=\"",
+                  "#{child[:name]}",
+                  "\">",
+                  child[:caption]
+                  |> Phoenix.HTML.html_escape()
+                  |> Phoenix.HTML.safe_to_string(),
+                  "</a>",
+                  "</div>"
+                ]
+              end)
+            ]
+          else
+            ""
+          end
+
+        _ ->
+          ""
+      end
+
+    if source_html != "" or refs_html != "" or enum do
+      [html, prefix_html, "<dd>", source_html, refs_html, options_html, "</dd>"]
     else
       html
     end


### PR DESCRIPTION
Implemented handling object enums on the UI and in the JSON generator. Also refactored similar code regarding class type to use the same logic.

Object enums are useful if only a limited scope of object are valid as a class/object attribute, that is, if the only valid choices are objects extending one specific object. This can be marked by the newly introduced `is_enum` field that can be aded to an attribute. Both in case of a `class_t` or `object_t`, the generator will pick an object/class that extends from the provided object/class. Example generated `Agent deployment` object (both `deployment_option` and `framework_config` are object enums):

![Screenshot 2025-04-07 at 13 24 47](https://github.com/user-attachments/assets/a0d8effd-a7d3-43ff-8f96-0e4d65173d60)

On the UI, an object page displays a new table is displayed with the children of the object, if it has any. Also there is a new `Options` section in the description of an object enum attribute with links to the eligible objects:

![Screenshot 2025-04-07 at 14 04 58](https://github.com/user-attachments/assets/880edcf3-32ab-483b-8d2c-64f939fe61d9)
![Screenshot 2025-04-07 at 12 55 38](https://github.com/user-attachments/assets/c22def5a-58b2-48d2-bdee-874e99f2564d)
