### PR TITLE
fix(server): displaying Options in description

### DIFF
--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -659,7 +659,7 @@ defmodule SchemaWeb.PageView do
         "object_t" ->
           children = Schema.Utils.find_children(Schema.objects(), obj[:object_type])
 
-          if children != nil do
+          if children != nil and !Enum.empty?(children) do
             [
               "<dt>Options<dd class=\"ml-3\">",
               Enum.map(children, fn child ->
@@ -684,7 +684,7 @@ defmodule SchemaWeb.PageView do
           ""
       end
 
-    if source_html != "" or refs_html != "" or enum do
+    if source_html != "" or refs_html != "" or options_html != "" do
       [html, prefix_html, "<dd>", source_html, refs_html, options_html, "</dd>"]
     else
       html


### PR DESCRIPTION
## Before
<img width="1139" alt="Screenshot 2025-04-09 at 16 44 49" src="https://github.com/user-attachments/assets/c73807bb-0ba0-41d8-b753-8e81305a1b18" />

## After

<img width="1129" alt="Screenshot 2025-04-09 at 16 45 04" src="https://github.com/user-attachments/assets/261a2f68-eb98-4b7e-9b58-ffb7b25caff3" />
