### PR TITLE
feat(schema): updating evaluation extension

### DIFF
--- a/schema/objects/metric.json
+++ b/schema/objects/metric.json
@@ -25,6 +25,11 @@
         }
       ]
     },
+    "url": {
+      "caption": "Reference",
+      "description": "The reference for this metric, giving some explainability for it.",
+      "requirement": "recommended"
+    },
     "data_points": {
       "caption": "Data Points",
       "requirement": "required",

--- a/schema/objects/publisher.json
+++ b/schema/objects/publisher.json
@@ -12,6 +12,11 @@
       "caption": "Version",
       "description": "Version of the publisher.",
       "requirement": "required"
+    },
+    "url": {
+      "caption": "URL",
+      "description": "Link to the publisher.",
+      "requirement": "recommended"
     }
   }
 }


### PR DESCRIPTION
This PR is adding an `url` attribute to the `metric` object, in order to provide explainability on what the metric represents and how it is computed. An `url` attribute is also added to the `publisher` object.