### PR TITLE
feat: implement string map type

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -33,8 +33,7 @@
     "annotations": {
       "caption": "Annotations",
       "description": "Provides additional metadata associated with the object. See specific usage.",
-      "type": "key_value_object",
-      "is_array": true
+      "type": "string_map_t"
     },
     "authentication": {
       "caption": "Authentication",
@@ -673,6 +672,10 @@
       "string_t": {
         "caption": "String",
         "description": "UTF-8 encoded byte sequence."
+      },
+      "string_map_t": {
+        "caption": "String Map",
+        "description": "A map of string to string."
       },
       "subnet_t": {
         "max_len": 42,

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -536,12 +536,12 @@ defmodule SchemaWeb.PageView do
           end
 
         "class_t" ->
-          class = Map.get(field, :path)
-          class_path = SchemaWeb.Router.Helpers.static_path(conn, "/#{class}")
+          family = Map.get(field, :family)
+          class_path = SchemaWeb.Router.Helpers.static_path(conn, "/#{family}s")
 
           case Map.get(field, :caption) do
             nil ->
-              "<a href='#{class_path}'>#{format_type(conn, class)}</a>"
+              "<a href='#{class_path}'>#{format_type(conn, family)}</a>"
 
             class_caption ->
               format_path(class_caption, class_path)


### PR DESCRIPTION
Modify `annotations` to use `string_map_t`, add validator for the type.

+1 quick fix for type formatting on the UI