### PR TITLE
chore: bump elixir:1.18.1-alpine -> 1.18.3-alpine

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG elixir_image=elixir:1.18.1-alpine
+ARG elixir_image=elixir:1.18.3-alpine
 
 FROM ${elixir_image} AS builder
 


### PR DESCRIPTION
closes #57 