### PR TITLE
fix: resolve docker image version mismatch in local deployment

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,8 +54,10 @@ tasks:
     desc: Build container images
     vars:
       BAKE_OPTS: '--set *.platform=linux/{{ARCH}}'
+      SCHEMA_VERSION:
+        sh: jq -r '.version' schema/version.json
     cmds:
-      - docker buildx bake {{.BAKE_OPTS}}
+      - IMAGE_TAG=v{{.SCHEMA_VERSION}} docker buildx bake {{.BAKE_OPTS}}
 
   release:
     desc: Release images for all components with a release tag


### PR DESCRIPTION
## Summary

Fixes docker image version mismatch that causes local deployment failure during `task up`.

## Problem

- `docker buildx bake` builds images with `latest` tag by default
- `values-test.yaml` expects images with versioned tags (e.g., `v0.3.1`)
- This mismatch causes "image not present locally" errors during Kind cluster deployment

## Solution

Modified `Taskfile.yml` to:
- Dynamically read version from `schema/version.json`
- Set `IMAGE_TAG` environment variable with proper `v` prefix during build
- Ensure consistent tagging between build and deployment processes

## Changes

- **Taskfile.yml**: Added `SCHEMA_VERSION` variable and dynamic `IMAGE_TAG` setting in `build:images` task

## Testing

Verified `task build:images` creates correctly tagged image  
Verified `task up` deploys successfully without manual intervention  
Tested version change (0.3.1 → 0.4.0) works dynamically  

## Benefits

- Fixes immediate deployment issue
- Future-proof - automatically adapts to version changes
- No hardcoded versions
- Maintains existing workflow compatibility

Fixes #141

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have verified this does not duplicate an existing fix
- [x] Changes have been tested locally
- [x] Commit includes DCO sign-off