### PR TITLE
feat(schema): add LLM/Prompt/A2A/MCP feature extensions

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -382,6 +382,12 @@
       "type": "llm_model",
       "is_array": true
     },
+    "llm_prompts": {
+      "caption": "List of LLM Prompts",
+      "description": "List of common prompts used for LLM interactions with the agent, including their configurations and parameters.",
+      "type": "llm_prompt",
+      "is_array": true
+    },
     "locator": {
       "caption": "Agent Locator",
       "description": "Locators provide actual artifact locators of an agent. For example, this can reference sources such as helm charts, docker images, binaries, and so on.",
@@ -471,6 +477,11 @@
       "caption": "ACP Endpoint",
       "description": "ACP endpoint description.",
       "type": "acp_endpoint"
+    },
+    "prompt": {
+      "caption": "Prompt Text",
+      "description": "A specific input or instruction given to a large language model (LLM) to generate text or perform a task.",
+      "type": "string_t"
     },
     "provider": {
       "caption": "Provider",

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -45,6 +45,16 @@
       "description": "Provides additional metadata associated with the object. See specific usage.",
       "type": "string_map_t"
     },
+    "api_base": {
+      "caption": "API Base URL",
+      "description": "URL of the API base for the LLM model (e.g., 'https://api.openai.com/v1').",
+      "type": "string_t"
+    },
+    "api_key": {
+      "caption": "API Key",
+      "description": "API key for accessing the LLM model, if required by the provider.",
+      "type": "string_t"
+    },
     "args": {
       "caption": "Arguments",
       "description": "A list of arguments to be passed to a command. See specific usage.",
@@ -366,6 +376,12 @@
       "type": "interrupts",
       "is_array": true
     },
+    "llm_models": {
+      "caption": "List of LLM Model Data",
+      "description": "Collection of LLM models supported by the agent, including their configurations and parameters.",
+      "type": "llm_model",
+      "is_array": true
+    },
     "locator": {
       "caption": "Agent Locator",
       "description": "Locators provide actual artifact locators of an agent. For example, this can reference sources such as helm charts, docker images, binaries, and so on.",
@@ -455,6 +471,11 @@
       "caption": "ACP Endpoint",
       "description": "ACP endpoint description.",
       "type": "acp_endpoint"
+    },
+    "provider": {
+      "caption": "Provider",
+      "description": "Name of the provider of a service, tool, object, etc. See specific usage.",
+      "type": "string_t"
     },
     "publisher": {
       "caption": "Publisher",

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -45,6 +45,12 @@
       "description": "Provides additional metadata associated with the object. See specific usage.",
       "type": "string_map_t"
     },
+    "args": {
+      "caption": "Arguments",
+      "description": "A list of arguments to be passed to a command. See specific usage.",
+      "type": "string_t",
+      "is_array": true
+    },
     "authentication": {
       "caption": "Authentication",
       "description": "This object contains an instance of an OpenAPI schema object, formatted as per the OpenAPI specs: <a target='_blank' href='https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object-0' >Security Scheme Object</a>.",
@@ -153,6 +159,11 @@
     "content_type": {
       "caption": "Content Type",
       "description": "Type of the content. See specific usage.",
+      "type": "string_t"
+    },
+    "command": {
+      "caption": "Command",
+      "description": "A command to be ran. See specific usage.",
       "type": "string_t"
     },
     "cost_score": {
@@ -329,6 +340,11 @@
       "description": "A json input.",
       "type": "json_t"
     },
+    "input_id": {
+      "caption": "Input ID",
+      "description": "The unique identifier of the input. See specific usage.",
+      "type": "string_t"
+    },
     "interrupt_payload": {
       "caption": "Interrupt Payload",
       "description": "An instance of an OpenAPI schema object, formatted as per the OpenAPI specs: <a target='_blank' href='https://spec.openapis.org/oas/v3.1.1.html#schema-object' >Schema Object</a>.",
@@ -359,6 +375,18 @@
       "caption": "Agent Locators",
       "description": "Locators provide actual artifact locators of an agent. For example, this can reference sources such as helm charts, docker images, binaries, and so on.",
       "type": "locator",
+      "is_array": true
+    },
+    "mcp_server_inputs": {
+      "caption": "MCP Server Inputs",
+      "description": "List of inputs that the agent can provide to the MCP servers.",
+      "type": "mcp_server_input",
+      "is_array": true
+    },
+    "mcp_servers": {
+      "caption": "MCP Servers",
+      "description": "List of MCP servers that the agent can connect to.",
+      "type": "mcp_server_configuration",
       "is_array": true
     },
     "metadata": {
@@ -402,6 +430,11 @@
       "caption": "Parent Unique ID",
       "description": "The unique identifier of an object's parent object. See specific usage.",
       "type": "string_t"
+    },
+    "password": {
+      "caption": "Password",
+      "description": "The password that pertains to the class or object. See specific usage.",
+      "type": "boolean_t"
     },
     "path": {
       "caption": "Path",

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -3,6 +3,11 @@
   "description": "The Attribute Dictionary defines attributes and includes references to the classes and objects in which they are used.",
   "name": "dictionary",
   "attributes": {
+    "a2a_card": {
+      "caption": "A2A Agent Card Data",
+      "description": "Content of the A2A card in JSON format.",
+      "type": "json_t"
+    },
     "acp": {
       "caption": "Agent Connect Protocol Specs",
       "description": "Specification of agent capabilities, config, input, output, and interrupts.",

--- a/schema/features/runtime/a2a.json
+++ b/schema/features/runtime/a2a.json
@@ -1,0 +1,17 @@
+{
+  "uid": 5,
+  "caption": "A2A Card",
+  "description": "Describes A2A card details for communication and usage with A2A protocol.",
+  "extends": "runtime",
+  "name": "a2a",
+  "attributes": {
+    "data": {
+      "caption": "Data",
+      "description": "Data supported by the agent for A2A card.",
+      "requirement": "required",
+      "type:": "object_t",
+      "object_type": "a2a_card_data",
+      "object_name": "A2A Card Data"
+    }
+  }
+}

--- a/schema/features/runtime/mcp_server.json
+++ b/schema/features/runtime/mcp_server.json
@@ -1,0 +1,17 @@
+{
+  "uid": 2,
+  "caption": "MCP",
+  "description": "Describes MCP servers required to run and interact with the agent.",
+  "extends": "runtime",
+  "name": "mcp",
+  "attributes": {
+    "data": {
+      "caption": "Data",
+      "description": "Data supported by the agent for MCP server.",
+      "requirement": "required",
+      "type:": "object_t",
+      "object_type": "mcp_server_data",
+      "object_name": "MCP Server Data"
+    }
+  }
+}

--- a/schema/features/runtime/model.json
+++ b/schema/features/runtime/model.json
@@ -1,0 +1,17 @@
+{
+  "uid": 3,
+  "caption": "LLM Model",
+  "description": "Describes LLM support and its configuration for a given agent.",
+  "extends": "runtime",
+  "name": "model",
+  "attributes": {
+    "data": {
+      "caption": "Data",
+      "description": "Data supported by the agent for LLM model.",
+      "requirement": "required",
+      "type:": "object_t",
+      "object_type": "llm_model_data",
+      "object_name": "LLM Model Data"
+    }
+  }
+}

--- a/schema/features/runtime/prompt.json
+++ b/schema/features/runtime/prompt.json
@@ -1,0 +1,17 @@
+{
+  "uid": 4,
+  "caption": "LLM Prompt",
+  "description": "Describes common LLM interaction prompts to use the agent.",
+  "extends": "runtime",
+  "name": "prompt",
+  "attributes": {
+    "data": {
+      "caption": "Data",
+      "description": "Data supported by the agent for LLM prompt.",
+      "requirement": "required",
+      "type:": "object_t",
+      "object_type": "llm_prompt_data",
+      "object_name": "LLM Prompt Data"
+    }
+  }
+}

--- a/schema/objects/a2a_card_data.json
+++ b/schema/objects/a2a_card_data.json
@@ -1,0 +1,19 @@
+{
+  "caption": "A2A Card Data",
+  "description": "Data for the A2A card agent record extension.",
+  "extends": "extension_data",
+  "name": "a2a_card_data",
+  "attributes": {
+    "a2a_card": {
+      "caption": "A2A Agent Card Data",
+      "description": "Content of the A2A card in JSON format.",
+      "requirement": "required",
+      "references": [
+        {
+          "description": "A2A Card Data Schema",
+          "url": "https://github.com/google-a2a/A2A/blob/main/docs/specification.md#55-agentcard-object-structure"
+        }
+      ]
+    }
+  }
+}

--- a/schema/objects/llm_model.json
+++ b/schema/objects/llm_model.json
@@ -1,0 +1,28 @@
+{
+  "caption": "LLM Model Configuration",
+  "description": "Configures the MCP server for LLM model support.",
+  "extends": "object",
+  "name": "llm_model",
+  "attributes": {
+    "name": {
+      "caption": "Model Name",
+      "description": "Name of the LLM model including its version (e.g., 'gpt-3.5-turbo').",
+      "requirement": "required"
+    },
+    "provider": {
+      "caption": "Provider",
+      "description": "Provider of the LLM model (e.g., 'ollama', 'azure').",
+      "requirement": "required"
+    },
+    "api_base": {
+      "caption": "API Base URL",
+      "description": "URL of the API base for the LLM model (e.g., 'https://api.openai.com/v1').",
+      "requirement": "required"
+    },
+    "api_key": {
+      "caption": "API Key",
+      "description": "API key for accessing the LLM model, if required by the provider.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/objects/llm_model_data.json
+++ b/schema/objects/llm_model_data.json
@@ -1,0 +1,13 @@
+{
+  "caption": "LLM Model Data",
+  "description": "Data for the LLM model agent record extension.",
+  "extends": "extension_data",
+  "name": "llm_model_data",
+  "attributes": {
+    "llm_models": {
+      "caption": "LLM Model Data",
+      "description": "Collection of LLM models supported by the agent, including their configurations and parameters.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/objects/llm_prompt.json
+++ b/schema/objects/llm_prompt.json
@@ -1,0 +1,23 @@
+{
+  "caption": "Prompt",
+  "description": "Defines the structure for LLM prompts used in agent interactions.",
+  "extends": "object",
+  "name": "llm_prompt",
+  "attributes": {
+    "name": {
+      "caption": "Prompt Name",
+      "description": "Name of the prompt, used to identify it in the system.",
+      "requirement": "required"
+    },
+    "description": {
+      "caption": "Description",
+      "description": "Description of the prompt, providing context and usage information.",
+      "requirement": "required"
+    },
+    "prompt": {
+      "caption": "Prompt Text",
+      "description": "A specific input or instruction given to a large language model (LLM) to generate text or perform a task.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/objects/llm_prompt_data.json
+++ b/schema/objects/llm_prompt_data.json
@@ -1,0 +1,13 @@
+{
+  "caption": "LLM Prompt Data",
+  "description": "Data for the LLM prompt agent record extension.",
+  "extends": "extension_data",
+  "name": "llm_prompt_data",
+  "attributes": {
+    "llm_prompts": {
+      "caption": "LLM Prompts",
+      "description": "List of common prompts used for LLM interactions with the agent, including their configurations and parameters.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/objects/mcp_server_configurations.json
+++ b/schema/objects/mcp_server_configurations.json
@@ -1,0 +1,28 @@
+{
+  "caption": "MCP Server Configuration",
+  "description": "Registry of configured MCP servers with execution parameters.",
+  "extends": "object",
+  "name": "mcp_server_configuration",
+  "attributes": {
+    "name": {
+      "caption": "Server Name",
+      "description": "Name for the MCP server",
+      "requirement": "required"
+    },
+    "command": {
+      "caption": "Command",
+      "description": "Executable or runtime command",
+      "requirement": "required"
+    },
+    "args": {
+      "caption": "Arguments",
+      "description": "Command-line arguments",
+      "requirement": "optional"
+    },
+    "env_vars": {
+      "caption": "Environment Variables",
+      "description": "Environment variables with input references",
+      "requirement": "optional"
+    }
+  }
+}

--- a/schema/objects/mcp_server_data.json
+++ b/schema/objects/mcp_server_data.json
@@ -1,0 +1,18 @@
+{
+	"caption": "MCP Server Configuration",
+	"description": "Data for the MCP server agent record extension.",
+	"extends": "extension_data",
+	"name": "mcp_server_data",
+	"attributes": {
+		"mcp_server_inputs": {
+			"caption": "User Inputs",
+			"description": "Collection of sensitive values requiring user input during server initialization.",
+			"requirement": "required"
+		},
+		"mcp_servers": {
+			"caption": "MCP Server Configurations",
+			"description": "Registry of configured MCP servers with execution parameters.",
+			"requirement": "required"
+		}
+	}
+}

--- a/schema/objects/mcp_server_input.json
+++ b/schema/objects/mcp_server_input.json
@@ -1,0 +1,28 @@
+{
+  "caption": "MCP Server Input",
+  "description": "Defines a user-supplied input required for MCP server configuration or authentication.",
+  "extends": "object",
+  "name": "mcp_server_input",
+  "attributes": {
+    "input_id": {
+      "caption": "Input ID",
+      "description": "Unique identifier for the input field (used for reference in environment variables or configuration).",
+      "requirement": "required"
+    },
+    "type": {
+      "caption": "Input Type",
+      "description": "Method by which the input is collected (e.g., promptString, pickString, pickBoolean).",
+      "requirement": "required"
+    },
+    "description": {
+      "caption": "Input Description",
+      "description": "Human-readable explanation of what this input is and how it will be used.",
+      "requirement": "required"
+    },
+    "password": {
+      "caption": "Password",
+      "description": "Indicates if the input should be obscured for privacy/security (true for sensitive data like tokens or passwords).",
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
Added new features under `runtime` category:

- [X] MCP server
- [X] LLM model
- [X] LLM prompt
- [x] A2A card

Attributes are not a 100% match until https://github.com/agntcy/oasf/issues/150 is completed.

Closes #130 
Closes #131 
Closes #132 