### PR TITLE
Fix/base class feature error

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,8 +54,10 @@ tasks:
     desc: Build container images
     vars:
       BAKE_OPTS: '--set *.platform=linux/{{ARCH}}'
+      SCHEMA_VERSION:
+        sh: jq -r '.version' schema/version.json
     cmds:
-      - docker buildx bake {{.BAKE_OPTS}}
+      - IMAGE_TAG=v{{.SCHEMA_VERSION}} docker buildx bake {{.BAKE_OPTS}}
 
   release:
     desc: Release images for all components with a release tag


### PR DESCRIPTION
## Summary

Fixes the internal error that occurs when accessing base_class as a feature.

## Problem

When navigating to https://schema.oasf.agntcy.org/features/base_class, an internal error occurs because base_class is not actually a feature class but is located in the root schema directory.

## Solution

Added special handling for base_class in:
- `features` function - renders base_class directly when accessed via /features/base_class
- `feature_graph` function - renders base_class graph directly when accessed via /feature/graph/base_class

## Changes

- **page_controller.ex**: Added conditional checks to handle base_class specially

## Testing

Verified that accessing /features/base_class now shows the base_class content
Verified that accessing /feature/graph/base_class now shows the base_class graph
No errors in server logs

Fixes #136
