### PR TITLE
feat: standardize reference names to use lowercase with underscores

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -470,7 +470,7 @@
     "acp": {
       "caption": "Agent Connect Protocol Specs",
       "description": "Specification of agent capabilities, config, input, output, and interrupts.",
-      "type": "acp"
+      "type": "agent_connect_protocol"
     },
     "streaming": {
       "caption": "Streaming Modes",

--- a/schema/domains/technology/iot.json
+++ b/schema/domains/technology/iot.json
@@ -3,6 +3,6 @@
   "caption": "Internet of Things (IoT)",
   "description": "Connecting everyday objects to the internet for data exchange and automation. Subdomains: IoT Devices, IoT Security, IoT Networks, Smart Homes, and Industrial IoT.",
   "extends": "technology",
-  "name": "iot",
+  "name": "internet_of_things",
   "attributes": {}
 }

--- a/schema/main_skills.json
+++ b/schema/main_skills.json
@@ -3,7 +3,7 @@
   "description": "A structured view of distinct abilities, defining the capabilities within the Open Agentic Schema Framework.",
   "name": "category",
   "attributes": {
-    "nlp": {
+    "natural_language_processing": {
       "uid": 1,
       "caption": "Natural Language Processing",
       "description": "Natural Language Processing (NLP) tasks are the application of computational techniques to the analysis and synthesis of natural language and speech."

--- a/schema/objects/acp.json
+++ b/schema/objects/acp.json
@@ -2,7 +2,7 @@
   "caption": "Agent Connect Protocol Specs",
   "description": "Specification of agent capabilities, config, input, output, and interrupts.",
   "extends": "object",
-  "name": "acp",
+  "name": "agent_connect_protocol",
   "attributes": {
     "capabilities": {
       "caption": "Capabilities",

--- a/schema/skills/nlp/analytical_reasoning/analytical_reasoning.json
+++ b/schema/skills/nlp/analytical_reasoning/analytical_reasoning.json
@@ -2,7 +2,7 @@
   "uid": 7,
   "caption": "Analytical and Logical Reasoning",
   "description": "Capabilities for performing logical analysis, inference, and problem-solving tasks.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "analytical_reasoning",
   "attributes": {}
 }

--- a/schema/skills/nlp/creative_content/creative_content.json
+++ b/schema/skills/nlp/creative_content/creative_content.json
@@ -2,7 +2,7 @@
   "uid": 4,
   "caption": "Creative Content Generation",
   "description": "Capabilities for generating various forms of creative content, including narratives, poetry, and other creative writing forms.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "creative_content",
   "attributes": {}
 }

--- a/schema/skills/nlp/ethical_interaction/ethical_interaction.json
+++ b/schema/skills/nlp/ethical_interaction/ethical_interaction.json
@@ -2,7 +2,7 @@
   "uid": 8,
   "caption": "Ethical and Safe Interaction",
   "description": "Capabilities for ensuring ethical, unbiased, and safe content generation and interaction.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "ethical_interaction",
   "attributes": {}
 }

--- a/schema/skills/nlp/feature_extraction/feature_extraction.json
+++ b/schema/skills/nlp/feature_extraction/feature_extraction.json
@@ -2,7 +2,7 @@
   "uid": 10,
   "caption": "Feature Extraction",
   "description": "Capabilities for extracting and representing textual features as vectors for downstream tasks.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "feature_extraction",
   "attributes": {}
 }

--- a/schema/skills/nlp/information_retrieval_synthesis/information_retrieval_synthesis.json
+++ b/schema/skills/nlp/information_retrieval_synthesis/information_retrieval_synthesis.json
@@ -2,7 +2,7 @@
   "uid": 3,
   "caption": "Information Retrieval and Synthesis",
   "description": "Capabilities for retrieving relevant information from various sources and synthesizing it into coherent, contextually appropriate responses. This includes searching, extracting, combining, and presenting information in a meaningful way.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "information_retrieval_synthesis",
   "attributes": {}
 }

--- a/schema/skills/nlp/language_translation/language_translation.json
+++ b/schema/skills/nlp/language_translation/language_translation.json
@@ -2,7 +2,7 @@
   "uid": 5,
   "caption": "Language Translation and Multilingual Support",
   "description": "Capabilities for handling multiple languages, including translation and multilingual text processing.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "language_translation",
   "attributes": {}
 }

--- a/schema/skills/nlp/natural_language_generation/nlg.json
+++ b/schema/skills/nlp/natural_language_generation/nlg.json
@@ -2,7 +2,7 @@
   "uid": 2,
   "caption": "Natural Language Generation",
   "description": "Natural Language Generation (NLG) describes the ability to generate human-like text from structured data or other inputs.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "natural_language_generation",
   "attributes": {}
 }

--- a/schema/skills/nlp/natural_language_understanding/contextual_comprehension.json
+++ b/schema/skills/nlp/natural_language_understanding/contextual_comprehension.json
@@ -2,7 +2,7 @@
   "uid": 1,
   "caption": "Contextual Comprehension",
   "description": "Understanding the context and nuances of text input to provide relevant responses.",
-  "extends": "nlu",
+  "extends": "natural_language_understanding",
   "name": "contextual_comprehension",
   "attributes": {}
 }

--- a/schema/skills/nlp/natural_language_understanding/entity_recognition.json
+++ b/schema/skills/nlp/natural_language_understanding/entity_recognition.json
@@ -2,7 +2,7 @@
   "uid": 3,
   "caption": "Entity Recognition",
   "description": "Identifying and categorizing key entities within the text, such as names, dates, or locations.",
-  "extends": "nlu",
+  "extends": "natural_language_understanding",
   "name": "entity_recognition",
   "attributes": {}
 }

--- a/schema/skills/nlp/natural_language_understanding/nlu.json
+++ b/schema/skills/nlp/natural_language_understanding/nlu.json
@@ -2,7 +2,7 @@
   "uid": 1,
   "caption": "Natural Language Understanding",
   "description": "Natural Language Understanding (NLU) focuses on the ability to interpret and comprehend human language, including understanding context, semantics, and identifying key entities within text.",
-  "extends": "nlp",
-  "name": "nlu",
+  "extends": "natural_language_processing",
+  "name": "natural_language_understanding",
   "attributes": {}
 }

--- a/schema/skills/nlp/natural_language_understanding/semantic_understanding.json
+++ b/schema/skills/nlp/natural_language_understanding/semantic_understanding.json
@@ -2,7 +2,7 @@
   "uid": 2,
   "caption": "Semantic Understanding",
   "description": "Grasping the meaning and intent behind words and phrases.",
-  "extends": "nlu",
+  "extends": "natural_language_understanding",
   "name": "semantic_understanding",
   "attributes": {}
 }

--- a/schema/skills/nlp/nlp.json
+++ b/schema/skills/nlp/nlp.json
@@ -1,7 +1,7 @@
 {
   "caption": "Natural Language Processing",
-  "category": "nlp",
+  "category": "natural_language_processing",
   "extends": "base_skill",
-  "name": "nlp",
+  "name": "natural_language_processing",
   "attributes": {}
 }

--- a/schema/skills/nlp/personalization/personalization.json
+++ b/schema/skills/nlp/personalization/personalization.json
@@ -2,7 +2,7 @@
   "uid": 6,
   "caption": "Personalisation and Adaptation",
   "description": "Capabilities for adapting and personalizing content based on user context and preferences.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "personalization",
   "attributes": {}
 }

--- a/schema/skills/nlp/text_classification/text_classification.json
+++ b/schema/skills/nlp/text_classification/text_classification.json
@@ -2,7 +2,7 @@
   "uid": 9,
   "caption": "Text Classification",
   "description": "Capabilities for classifying and categorizing text into predefined categories or labels.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "text_classification",
   "attributes": {}
 }

--- a/schema/skills/nlp/token_classification/token_classification.json
+++ b/schema/skills/nlp/token_classification/token_classification.json
@@ -2,7 +2,7 @@
   "uid": 11,
   "caption": "Token Classification",
   "description": "Capabilities for classifying individual tokens or words within text.",
-  "extends": "nlp",
+  "extends": "natural_language_processing",
   "name": "token_classification",
   "attributes": {}
 }


### PR DESCRIPTION
## Summary
Standardizes reference names across the schema to follow a consistent pattern as requested in #148.

## Changes Made
- **nlu** → **natural_language_understanding**
- **nlp** → **natural_language_processing**  
- **iot** → **internet_of_things**
- **acp** → **agent_connect_protocol**

## Files Modified (19 total)
- Updated primary schema files with new reference names
- Updated all dependent files that extend or reference the changed names
- Updated dictionary.json and main_skills.json for consistency
- Fixed category references to prevent undefined category warnings

## Pattern Applied
All reference names now follow the pattern: **caption in lowercase with underscores**
- Example: "Natural Language Understanding" → `natural_language_understanding`

## Testing
- All JSON files are syntactically valid
- Server builds and runs without errors
- No undefined category warnings in server logs
- Web interface displays new reference names correctly
- All API endpoints respond successfully

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have verified this does not duplicate an existing fix
- [x] Changes have been tested locally
- [x] Commit includes DCO sign-off

## Fixes
Closes #148
