### PR TITLE
fix: local dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ It also sets up port forwarding
 so that the services can be accessed locally.
 
 ```shell
+IMAGE_TAG=latest task build:images
 task up
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,10 +54,8 @@ tasks:
     desc: Build container images
     vars:
       BAKE_OPTS: '--set *.platform=linux/{{ARCH}}'
-      SCHEMA_VERSION:
-        sh: jq -r '.version' schema/version.json
     cmds:
-      - IMAGE_TAG=v{{.SCHEMA_VERSION}} docker buildx bake {{.BAKE_OPTS}}
+      - docker buildx bake {{.BAKE_OPTS}}
 
   release:
     desc: Release images for all components with a release tag

--- a/install/charts/oasf/templates/ingress/ingress-api.yaml
+++ b/install/charts/oasf/templates/ingress/ingress-api.yaml
@@ -56,6 +56,15 @@ spec:
                 name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
                 port:
                   number: {{ $svcPort }}
+            {{- if $version.default }}
+          - path: /api(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
+                port:
+                  number: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/install/charts/oasf/templates/ingress/ingress-export.yaml
+++ b/install/charts/oasf/templates/ingress/ingress-export.yaml
@@ -56,6 +56,15 @@ spec:
                 name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
                 port:
                   number: {{ $svcPort }}
+            {{- if $version.default }}
+          - path: /export(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
+                port:
+                  number: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/install/charts/oasf/templates/ingress/ingress-sample.yaml
+++ b/install/charts/oasf/templates/ingress/ingress-sample.yaml
@@ -56,6 +56,15 @@ spec:
                 name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
                 port:
                   number: {{ $svcPort }}
+            {{- if $version.default }}
+          - path: /sample(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
+                port:
+                  number: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/install/charts/oasf/templates/ingress/ingress-schema.yaml
+++ b/install/charts/oasf/templates/ingress/ingress-schema.yaml
@@ -56,6 +56,15 @@ spec:
                 name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
                 port:
                   number: {{ $svcPort }}
+            {{- if $version.default }}
+          - path: /schema(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-{{ $version.schema | replace "." "-" }}
+                port:
+                  number: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/install/charts/oasf/values-test.yaml
+++ b/install/charts/oasf/values-test.yaml
@@ -4,7 +4,7 @@
 image:
   repository: ghcr.io/agntcy/oasf-server
   versions:
-    - server: v0.3.1
+    - server: latest
       schema: 0.3.1
       default: true
   pullPolicy: IfNotPresent


### PR DESCRIPTION
- reverted #142 in favor of using the `latest` tag in the `values-test.yaml` because that implementation prevented overwriting the image tag (e.g. `IMAGE_TAG=v0.3.3 task build:images`, also it is better to use the `latest` tag for development than overwriting an official release
- added default ingress paths to the helm templates so trying out the endpoints work on the Swagger UI 

Still fixes #141 