### PR TITLE
feat: remove general classes, categories

### DIFF
--- a/schema/metaschema/categories.schema.json
+++ b/schema/metaschema/categories.schema.json
@@ -2,7 +2,7 @@
     "$id": "https://schema.oasf.agntcy.org/categories.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Categories",
-    "description": "The OASF categories organize agent skill classes, each aligned with a specific domain or area of focus.",
+    "description": "The OASF categories organize agent skill, domain or feature classes, each aligned with a specific domain or area of focus.",
     "type": "object",
     "properties": {
         "annotations": {

--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -99,9 +99,9 @@ defmodule Schema.Cache do
     # Check profiles used in objects, adding objects to profile's _links
     profiles = Profiles.sanity_check(:object, objects, profiles)
     # Check profiles used in classes, adding classes to profile's _links
-    profiles = Profiles.sanity_check(:class, skills, profiles)
-    profiles = Profiles.sanity_check(:class, domains, profiles)
-    profiles = Profiles.sanity_check(:class, features, profiles)
+    profiles = Profiles.sanity_check(:skill, skills, profiles)
+    profiles = Profiles.sanity_check(:domain, domains, profiles)
+    profiles = Profiles.sanity_check(:feature, features, profiles)
 
     # Missing description warnings, datetime attributes, and profiles
     objects =

--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -18,9 +18,6 @@ defmodule Schema.Cache do
     :profiles,
     :dictionary,
     :base_class,
-    :classes,
-    :all_classes,
-    :categories,
     :objects,
     :all_objects,
     # domain libs
@@ -37,7 +34,7 @@ defmodule Schema.Cache do
     :main_features
   ]
   defstruct ~w[
-    version profiles dictionary base_class classes all_classes categories objects all_objects skills all_skills main_skills domains all_domains main_domains features all_features main_features
+    version profiles dictionary base_class objects all_objects skills all_skills main_skills domains all_domains main_domains features all_features main_features
   ]a
 
   @type t() :: %__MODULE__{}
@@ -89,23 +86,10 @@ defmodule Schema.Cache do
         version[:version]
       )
 
-    # Merge skills, domains and features classes and categories
-    classes = Utils.merge_classes([skills, domains, features])
-    all_classes = Utils.merge_classes([all_skills, all_domains, all_features])
-
-    categories_attributes =
-      Utils.merge_categories([
-        main_skills[:attributes],
-        main_domains[:attributes],
-        main_features[:attributes]
-      ])
-
-    categories = %{attributes: categories_attributes}
-
     {objects, all_objects} =
       read_objects(version[:version])
 
-    dictionary = Utils.update_dictionary(dictionary, base_class, classes, objects)
+    dictionary = Utils.update_dictionary(dictionary, base_class, skills, domains, features, objects)
     dictionary_attributes = dictionary[:attributes]
 
     # Read and update profiles
@@ -115,17 +99,15 @@ defmodule Schema.Cache do
     # Check profiles used in objects, adding objects to profile's _links
     profiles = Profiles.sanity_check(:object, objects, profiles)
     # Check profiles used in classes, adding classes to profile's _links
-    profiles = Profiles.sanity_check(:class, classes, profiles)
+    profiles = Profiles.sanity_check(:class, skills, profiles)
+    profiles = Profiles.sanity_check(:class, domains, profiles)
+    profiles = Profiles.sanity_check(:class, features, profiles)
 
     # Missing description warnings, datetime attributes, and profiles
     objects =
       objects
       |> Utils.update_objects(dictionary_attributes)
       |> update_objects()
-      |> final_check(dictionary_attributes)
-
-    classes =
-      update_classes(classes, objects)
       |> final_check(dictionary_attributes)
 
     skills =
@@ -146,7 +128,6 @@ defmodule Schema.Cache do
     no_req_set = MapSet.new()
     {profiles, no_req_set} = fix_entities(profiles, no_req_set, "profile")
     {base_class, no_req_set} = fix_entity(base_class, no_req_set, :base_class, "class")
-    {classes, no_req_set} = fix_entities(classes, no_req_set, "class")
     {skills, no_req_set} = fix_entities(skills, no_req_set, "skill")
     {domains, no_req_set} = fix_entities(domains, no_req_set, "domain")
     {features, no_req_set} = fix_entities(features, no_req_set, "feature")
@@ -166,9 +147,6 @@ defmodule Schema.Cache do
       profiles: profiles,
       dictionary: dictionary,
       base_class: base_class,
-      classes: classes,
-      all_classes: all_classes,
-      categories: categories,
       objects: objects,
       all_objects: all_objects,
       # skill libs
@@ -210,14 +188,6 @@ defmodule Schema.Cache do
   @spec dictionary(__MODULE__.t()) :: dictionary_t()
   def dictionary(%__MODULE__{dictionary: dictionary}), do: dictionary
 
-  @spec categories(__MODULE__.t()) :: map()
-  def categories(%__MODULE__{categories: categories}), do: categories
-
-  @spec category(__MODULE__.t(), any) :: nil | category_t()
-  def category(%__MODULE__{categories: categories}, id) do
-    Map.get(categories[:attributes], id)
-  end
-
   @spec main_skills(__MODULE__.t()) :: map()
   def main_skills(%__MODULE__{main_skills: main_skills}), do: main_skills
 
@@ -242,40 +212,12 @@ defmodule Schema.Cache do
     Map.get(main_features[:attributes], id)
   end
 
-  @spec classes(__MODULE__.t()) :: map()
-  def classes(%__MODULE__{classes: classes}), do: classes
-
-  @spec all_classes(__MODULE__.t()) :: map()
-  def all_classes(%__MODULE__{all_classes: all_classes}), do: all_classes
-
   @spec all_objects(__MODULE__.t()) :: map()
   def all_objects(%__MODULE__{all_objects: all_objects}), do: all_objects
-
-  @spec export_classes(__MODULE__.t()) :: map()
-  def export_classes(%__MODULE__{classes: classes, dictionary: dictionary}) do
-    Enum.into(classes, Map.new(), fn {name, class} ->
-      {name, enrich(class, dictionary[:attributes])}
-    end)
-  end
 
   @spec export_base_class(__MODULE__.t()) :: map()
   def export_base_class(%__MODULE__{base_class: base_class, dictionary: dictionary}) do
     enrich(base_class, dictionary[:attributes])
-  end
-
-  @spec class(__MODULE__.t(), atom()) :: nil | class_t()
-  def class(%__MODULE__{dictionary: dictionary, base_class: base_class}, :base_class) do
-    enrich(base_class, dictionary[:attributes])
-  end
-
-  def class(%__MODULE__{dictionary: dictionary, classes: classes}, id) do
-    case Map.get(classes, id) do
-      nil ->
-        nil
-
-      class ->
-        enrich(class, dictionary[:attributes])
-    end
   end
 
   @spec skills(__MODULE__.t()) :: map()

--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -89,7 +89,7 @@ defmodule Schema.Cache do
     {objects, all_objects} =
       read_objects(version[:version])
 
-    dictionary = Utils.update_dictionary(dictionary, base_class, skills, domains, features, objects)
+    dictionary = Utils.update_dictionary(dictionary, skills, domains, features, objects)
     dictionary_attributes = dictionary[:attributes]
 
     # Read and update profiles

--- a/server/lib/schema/repo.ex
+++ b/server/lib/schema/repo.ex
@@ -40,41 +40,6 @@ defmodule Schema.Repo do
     Agent.get(__MODULE__, fn schema -> Cache.profiles(schema) |> filter(extensions) end)
   end
 
-  @spec categories :: map()
-  def categories() do
-    Agent.get(__MODULE__, fn schema -> Cache.categories(schema) end)
-  end
-
-  @spec categories(extensions_t() | nil) :: map()
-  def categories(nil) do
-    Agent.get(__MODULE__, fn schema -> Cache.categories(schema) end)
-  end
-
-  def categories(extensions) do
-    Agent.get(__MODULE__, fn schema ->
-      Cache.categories(schema)
-      |> Map.update!(:attributes, fn attributes -> filter(attributes, extensions) end)
-    end)
-  end
-
-  @spec category(atom) :: nil | Cache.category_t()
-  def category(id) do
-    category(nil, id)
-  end
-
-  @spec category(extensions_t() | nil, atom) :: nil | Cache.category_t()
-  def category(extensions, id) do
-    Agent.get(__MODULE__, fn schema ->
-      case Cache.category(schema, id) do
-        nil ->
-          nil
-
-        category ->
-          add_classes(extensions, {id, category}, Cache.classes(schema))
-      end
-    end)
-  end
-
   @spec main_skills :: map()
   def main_skills() do
     Agent.get(__MODULE__, fn schema -> Cache.main_skills(schema) end)
@@ -204,25 +169,6 @@ defmodule Schema.Repo do
     end)
   end
 
-  @spec classes() :: map()
-  def classes() do
-    Agent.get(__MODULE__, fn schema -> Cache.classes(schema) end)
-  end
-
-  @spec classes(extensions_t() | nil) :: map()
-  def classes(nil) do
-    Agent.get(__MODULE__, fn schema -> Cache.classes(schema) end)
-  end
-
-  def classes(extensions) do
-    Agent.get(__MODULE__, fn schema -> Cache.classes(schema) |> filter(extensions) end)
-  end
-
-  @spec all_classes() :: map()
-  def all_classes() do
-    Agent.get(__MODULE__, fn schema -> Cache.all_classes(schema) end)
-  end
-
   @spec skills() :: map()
   def skills() do
     Agent.get(__MODULE__, fn schema -> Cache.skills(schema) end)
@@ -285,22 +231,6 @@ defmodule Schema.Repo do
     Agent.get(__MODULE__, fn schema -> Cache.all_objects(schema) end)
   end
 
-  @spec export_classes() :: map()
-  def export_classes() do
-    Agent.get(__MODULE__, fn schema -> Cache.export_classes(schema) end)
-  end
-
-  @spec export_classes(extensions_t() | nil) :: map()
-  def export_classes(nil) do
-    Agent.get(__MODULE__, fn schema -> Cache.export_classes(schema) end)
-  end
-
-  def export_classes(extensions) do
-    Agent.get(__MODULE__, fn schema ->
-      Cache.export_classes(schema) |> filter(extensions)
-    end)
-  end
-
   @spec export_skills() :: map()
   def export_skills() do
     Agent.get(__MODULE__, fn schema -> Cache.export_skills(schema) end)
@@ -352,11 +282,6 @@ defmodule Schema.Repo do
   @spec export_base_class() :: map()
   def export_base_class() do
     Agent.get(__MODULE__, fn schema -> Cache.export_base_class(schema) end)
-  end
-
-  @spec class(atom) :: nil | Cache.class_t()
-  def class(id) do
-    Agent.get(__MODULE__, fn schema -> Cache.class(schema, id) end)
   end
 
   @spec skill(atom) :: nil | Cache.class_t()

--- a/server/lib/schema/repo.ex
+++ b/server/lib/schema/repo.ex
@@ -70,7 +70,7 @@ defmodule Schema.Repo do
           nil
 
         main_skill ->
-          add_skills(extensions, {id, main_skill}, Cache.skills(schema))
+          add_classes(extensions, {id, main_skill}, Cache.skills(schema))
       end
     end)
   end
@@ -105,7 +105,7 @@ defmodule Schema.Repo do
           nil
 
         main_domain ->
-          add_domains(extensions, {id, main_domain}, Cache.domains(schema))
+          add_classes(extensions, {id, main_domain}, Cache.domains(schema))
       end
     end)
   end
@@ -140,7 +140,7 @@ defmodule Schema.Repo do
           nil
 
         main_feature ->
-          add_features(extensions, {id, main_feature}, Cache.features(schema))
+          add_classes(extensions, {id, main_feature}, Cache.features(schema))
       end
     end)
   end
@@ -457,143 +457,5 @@ defmodule Schema.Repo do
       )
 
     Map.put(category, :classes, list)
-  end
-
-  defp add_skills(nil, {id, main_skill}, skills) do
-    main_skill_uid = Atom.to_string(id)
-
-    list =
-      skills
-      |> Stream.filter(fn {_name, skill} ->
-        md = Map.get(skill, :category)
-        md == main_skill_uid or Utils.to_uid(skill[:extension], md) == id
-      end)
-      |> Stream.map(fn {name, skill} ->
-        skill =
-          skill
-          |> Map.delete(:category)
-          |> Map.delete(:category_name)
-
-        {name, skill}
-      end)
-      |> Enum.to_list()
-
-    Map.put(main_skill, :classes, list)
-    |> Map.put(:name, main_skill_uid)
-  end
-
-  defp add_skills(extensions, {id, main_skill}, skills) do
-    main_skill_uid = Atom.to_string(id)
-
-    list =
-      Enum.filter(
-        skills,
-        fn {_name, skill} ->
-          md = skill[:category]
-
-          case skill[:extension] do
-            nil ->
-              md == main_skill_uid
-
-            ext ->
-              MapSet.member?(extensions, ext) and
-                (md == main_skill_uid or Utils.to_uid(ext, md) == id)
-          end
-        end
-      )
-
-    Map.put(main_skill, :classes, list)
-  end
-
-  defp add_domains(nil, {id, main_domain}, domains) do
-    main_domain_uid = Atom.to_string(id)
-
-    list =
-      domains
-      |> Stream.filter(fn {_name, domain} ->
-        md = Map.get(domain, :category)
-        md == main_domain_uid or Utils.to_uid(domain[:extension], md) == id
-      end)
-      |> Stream.map(fn {name, domain} ->
-        domain =
-          domain
-          |> Map.delete(:category)
-          |> Map.delete(:category_name)
-
-        {name, domain}
-      end)
-      |> Enum.to_list()
-
-    Map.put(main_domain, :classes, list)
-    |> Map.put(:name, main_domain_uid)
-  end
-
-  defp add_domains(extensions, {id, main_domain}, domains) do
-    main_domain_uid = Atom.to_string(id)
-
-    list =
-      Enum.filter(
-        domains,
-        fn {_name, domain} ->
-          md = domain[:category]
-
-          case domain[:extension] do
-            nil ->
-              md == main_domain_uid
-
-            ext ->
-              MapSet.member?(extensions, ext) and
-                (md == main_domain_uid or Utils.to_uid(ext, md) == id)
-          end
-        end
-      )
-
-    Map.put(main_domain, :classes, list)
-  end
-
-  defp add_features(nil, {id, main_feature}, features) do
-    main_feature_uid = Atom.to_string(id)
-
-    list =
-      features
-      |> Stream.filter(fn {_name, feature} ->
-        md = Map.get(feature, :category)
-        md == main_feature_uid or Utils.to_uid(feature[:extension], md) == id
-      end)
-      |> Stream.map(fn {name, feature} ->
-        feature =
-          feature
-          |> Map.delete(:category)
-          |> Map.delete(:category_name)
-
-        {name, feature}
-      end)
-      |> Enum.to_list()
-
-    Map.put(main_feature, :classes, list)
-    |> Map.put(:name, main_feature_uid)
-  end
-
-  defp add_features(extensions, {id, main_feature}, features) do
-    main_feature_uid = Atom.to_string(id)
-
-    list =
-      Enum.filter(
-        features,
-        fn {_name, feature} ->
-          md = feature[:category]
-
-          case feature[:extension] do
-            nil ->
-              md == main_feature_uid
-
-            ext ->
-              MapSet.member?(extensions, ext) and
-                (md == main_feature_uid or Utils.to_uid(ext, md) == id)
-          end
-        end
-      )
-
-    Map.put(main_feature, :classes, list)
   end
 end

--- a/server/lib/schema/translator.ex
+++ b/server/lib/schema/translator.ex
@@ -49,7 +49,7 @@ defmodule Schema.Translator do
             name ->
               if Schema.Types.is_oasf_class?(name) do
                 Logger.debug("translate feature class: #{name}")
-                Schema.feature(Schema.Types.extract_class_name(name))
+                Schema.feature(Path.basename(name))
               else
                 Logger.debug("not an OASF extension: #{name}")
                 data

--- a/server/lib/schema/types.ex
+++ b/server/lib/schema/types.ex
@@ -51,21 +51,6 @@ defmodule Schema.Types do
     "#{@schema_addr}/#{family}s/#{name}"
   end
 
-  @doc """
-  Extracts class name from longer class name.
-  """
-  def extract_class_name(name) do
-    case String.split(name, "/") do
-      [last] ->
-        # if there were no "/" characters, return the original string
-        last
-
-      list ->
-        # return the last part of the list
-        List.last(list)
-    end
-  end
-
   def is_oasf_class?(name) do
     String.starts_with?(name, @schema_addr)
   end

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -6,7 +6,7 @@ defmodule Schema.Utils do
   Defines map helper functions.
   """
   @type link_t() :: %{
-          :group => :common | :skill | :domain | :feature | :object,
+          :group => :skill | :domain | :feature | :object,
           :type => String.t(),
           :caption => String.t(),
           optional(:deprecated?) => boolean(),
@@ -81,12 +81,12 @@ defmodule Schema.Utils do
     end
   end
 
-  @spec update_dictionary(map, map, map, map, map, map) :: map
+  @spec update_dictionary(map, map, map, map, map) :: map
+  def update_dictionary(dictionary, skills, domains, features, objects) do
     dictionary
-    |> add_common_links(common)
-    |> link_classes(:skill, skill_classes)
-    |> link_classes(:domain, domain_classes)
-    |> link_classes(:feature, feature_classes)
+    |> link_classes(:skill, skills)
+    |> link_classes(:domain, domains)
+    |> link_classes(:feature, features)
     |> link_objects(objects)
     |> update_data_types(objects)
     |> define_datetime_attributes()
@@ -218,7 +218,7 @@ defmodule Schema.Utils do
     end
   end
 
-  @spec make_link(:common | :skill | :domain | :feature | :object, atom() | String.t(), map()) :: link_t()
+  @spec make_link(:skill | :domain | :feature | :object, atom() | String.t(), map()) :: link_t()
   def make_link(group, type, item) do
     if Map.has_key?(item, :"@deprecated") do
       %{
@@ -230,20 +230,6 @@ defmodule Schema.Utils do
     else
       %{group: group, type: to_string(type), caption: item[:caption] || "*No name*"}
     end
-  end
-
-  # Adds attribute's used-by links to the dictionary.
-  defp add_common_links(dict, class) do
-    Map.update!(dict, :attributes, fn attributes ->
-      link = make_link(:common, class[:name], class)
-
-      update_attributes(
-        class,
-        attributes,
-        link,
-        &update_dictionary_links/2
-      )
-    end)
   end
 
   defp add_class_links(dictionary, {class_key, class}, family) do

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -6,7 +6,7 @@ defmodule Schema.Utils do
   Defines map helper functions.
   """
   @type link_t() :: %{
-          :group => :common | :class | :object,
+          :group => :common | :skill | :domain | :feature | :object,
           :type => String.t(),
           :caption => String.t(),
           optional(:deprecated?) => boolean(),
@@ -82,12 +82,11 @@ defmodule Schema.Utils do
   end
 
   @spec update_dictionary(map, map, map, map, map, map) :: map
-  def update_dictionary(dictionary, common, skill_classes, domain_classes, feature_classes, objects) do
     dictionary
     |> add_common_links(common)
-    |> link_classes(skill_classes)
-    |> link_classes(domain_classes)
-    |> link_classes(feature_classes)
+    |> link_classes(:skill, skill_classes)
+    |> link_classes(:domain, domain_classes)
+    |> link_classes(:feature, feature_classes)
     |> link_objects(objects)
     |> update_data_types(objects)
     |> define_datetime_attributes()
@@ -150,9 +149,9 @@ defmodule Schema.Utils do
     |> Enum.to_list()
   end
 
-  defp link_classes(dictionary, classes) do
+  defp link_classes(dictionary, family, classes) do
     Enum.reduce(classes, dictionary, fn class, acc ->
-      add_class_links(acc, class)
+      add_class_links(acc, class, family)
     end)
   end
 
@@ -219,7 +218,7 @@ defmodule Schema.Utils do
     end
   end
 
-  @spec make_link(:common | :class | :object, atom() | String.t(), map()) :: link_t()
+  @spec make_link(:common | :skill | :domain | :feature | :object, atom() | String.t(), map()) :: link_t()
   def make_link(group, type, item) do
     if Map.has_key?(item, :"@deprecated") do
       %{
@@ -247,7 +246,7 @@ defmodule Schema.Utils do
     end)
   end
 
-  defp add_class_links(dictionary, {class_key, class}) do
+  defp add_class_links(dictionary, {class_key, class}, family) do
     Map.update!(dictionary, :attributes, fn dictionary_attributes ->
       type =
         case class[:name] do
@@ -255,7 +254,7 @@ defmodule Schema.Utils do
           _ -> class_key
         end
 
-      link = make_link(:class, type, class)
+      link = make_link(family, type, class)
 
       update_attributes(
         class,

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -81,11 +81,13 @@ defmodule Schema.Utils do
     end
   end
 
-  @spec update_dictionary(map, map, map, map) :: map
-  def update_dictionary(dictionary, common, classes, objects) do
+  @spec update_dictionary(map, map, map, map, map, map) :: map
+  def update_dictionary(dictionary, common, skill_classes, domain_classes, feature_classes, objects) do
     dictionary
     |> add_common_links(common)
-    |> link_classes(classes)
+    |> link_classes(skill_classes)
+    |> link_classes(domain_classes)
+    |> link_classes(feature_classes)
     |> link_objects(objects)
     |> update_data_types(objects)
     |> define_datetime_attributes()

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -329,25 +329,6 @@ defmodule Schema.Utils do
     )
   end
 
-  @spec merge_classes([map()]) :: map()
-  def merge_classes(maps) when is_list(maps) do
-    Enum.reduce(maps, %{}, fn map, acc ->
-      Map.merge(acc, map, fn
-        :base_class, val1, _val2 -> val1
-        key, _val1, _val2 -> raise ArgumentError, "Duplicate class names are forbidden: #{key}"
-      end)
-    end)
-  end
-
-  @spec merge_categories([map()]) :: map()
-  def merge_categories(maps) when is_list(maps) do
-    Enum.reduce(maps, %{}, fn map, acc ->
-      Map.merge(acc, map, fn
-        key, _val1, _val2 -> raise ArgumentError, "Duplicate category names are forbidden: #{key}"
-      end)
-    end)
-  end
-
   @spec deep_merge(map | nil, map | nil) :: map | nil
   def deep_merge(left, right) when is_map(left) and is_map(right) do
     Map.merge(left, right, &deep_resolve/3)

--- a/server/lib/schema/validator.ex
+++ b/server/lib/schema/validator.ex
@@ -288,8 +288,7 @@ defmodule Schema.Validator do
          input
        ) do
     if Map.has_key?(input, "name") do
-      name = input["name"]
-      class_name = Schema.Types.extract_class_name(name)
+      class_name = Path.basename(input["name"])
 
       cond do
         is_bitstring(class_name) ->

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -1143,22 +1143,6 @@ defmodule SchemaWeb.SchemaController do
   end
 
   @doc """
-  Returns the list of classes.
-  """
-  @spec classes(map) :: map
-  def classes(params) do
-    extensions = parse_options(extensions(params))
-
-    case parse_options(profiles(params)) do
-      nil ->
-        Schema.classes(extensions)
-
-      profiles ->
-        Schema.classes(extensions, profiles)
-    end
-  end
-
-  @doc """
   Get a skill by name.
   get /api/skills/:name
   """

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -1053,7 +1053,30 @@ defmodule SchemaWeb.PageView do
     groups = Enum.group_by(links, fn link -> link[:group] end)
 
     classes_html =
-      profile_links_class_to_html(conn, profile_name, groups[:class], list_presentation)
+      [
+        profile_links_class_to_html(
+          conn,
+          profile_name,
+          groups[:skill],
+          list_presentation,
+          "skill"
+        ),
+        profile_links_class_to_html(
+          conn,
+          profile_name,
+          groups[:domain],
+          list_presentation,
+          "domain"
+        ),
+        profile_links_class_to_html(
+          conn,
+          profile_name,
+          groups[:feature],
+          list_presentation,
+          "feature"
+        )
+      ]
+      |> Enum.reject(&Enum.empty?/1)
 
     objects_html = links_object_to_html(conn, profile_name, groups[:object], list_presentation)
 
@@ -1061,9 +1084,9 @@ defmodule SchemaWeb.PageView do
     |> Enum.intersperse("<hr>")
   end
 
-  defp profile_links_class_to_html(_, _, nil, _), do: []
+  defp profile_links_class_to_html(_, _, nil, _, _), do: []
 
-  defp profile_links_class_to_html(conn, profile_name, linked_classes, list_presentation) do
+  defp profile_links_class_to_html(conn, profile_name, linked_classes, list_presentation, family) do
     html_list =
       reverse_sort_links(linked_classes)
       |> Enum.reduce(
@@ -1072,7 +1095,7 @@ defmodule SchemaWeb.PageView do
           [
             [
               "<a href=\"",
-              SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type]),
+              SchemaWeb.Router.Helpers.static_path(conn, "/#{family}s/" <> link[:type]),
               "\">",
               link[:caption],
               " Class</a>",
@@ -1088,10 +1111,10 @@ defmodule SchemaWeb.PageView do
         []
 
       list_presentation == :collapse ->
-        noun_text = if length(html_list) == 1, do: " class", else: " classes"
+        noun_text = if length(html_list) == 1, do: " #{family}", else: " #{family}s"
 
         collapse_html(
-          ["class-links-", to_css_selector(profile_name)],
+          ["#{family}-links-", to_css_selector(profile_name)],
           ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
           Enum.intersperse(html_list, "<br>")
         )

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -899,7 +899,14 @@ defmodule SchemaWeb.PageView do
   def object_links(conn, name, links, list_presentation) do
     groups = Enum.group_by(links, fn link -> link[:group] end)
 
-    classes_html = object_links_class_to_html(conn, name, groups[:class], list_presentation)
+    classes_html =
+      [
+        object_links_class_to_html(conn, name, groups[:skill], list_presentation, "skill"),
+        object_links_class_to_html(conn, name, groups[:domain], list_presentation, "domain"),
+        object_links_class_to_html(conn, name, groups[:feature], list_presentation, "feature")
+      ]
+      |> Enum.reject(&Enum.empty?/1)
+
     objects_html = object_links_object_to_html(conn, name, groups[:object], list_presentation)
 
     Enum.reject([classes_html, objects_html], &Enum.empty?/1)
@@ -922,15 +929,15 @@ defmodule SchemaWeb.PageView do
     end
   end
 
-  defp object_links_class_to_html(_, _, nil, _), do: []
+  defp object_links_class_to_html(_, _, nil, _, _), do: []
 
-  defp object_links_class_to_html(conn, name, linked_classes, list_presentation) do
+  defp object_links_class_to_html(conn, name, linked_classes, list_presentation, family) do
     html_list =
       reverse_sort_links(linked_classes)
       |> Enum.reduce(
         [],
         fn link, acc ->
-          type_path = SchemaWeb.Router.Helpers.static_path(conn, "/classes/" <> link[:type])
+          type_path = SchemaWeb.Router.Helpers.static_path(conn, "/#{family}s/" <> link[:type])
 
           [
             if list_presentation == :collapse do
@@ -966,10 +973,10 @@ defmodule SchemaWeb.PageView do
         []
 
       list_presentation == :collapse ->
-        noun_text = if length(html_list) == 1, do: " class", else: " classes"
+        noun_text = if length(html_list) == 1, do: " #{family}", else: " #{family}s"
 
         collapse_html(
-          ["class-links-", to_css_selector(name)],
+          ["#{family}-links-", to_css_selector(name)],
           ["Referenced by ", Integer.to_string(length(html_list)), noun_text],
           Enum.intersperse(html_list, "<br>")
         )


### PR DESCRIPTION
Removed general classes, categories maps (where all the classes, categories were merged together from all class families) from cache and all references.

Bonus: references to classes are also fixed on the Dictionary, Objects and Profiles page.

Fixes #158 