### PR TITLE
ci: release helm chart separately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
       - main
     tags:
       - "v*.*.*"
+      - "helm/v*.*.*"
   pull_request:
 
 permissions:
@@ -107,8 +108,8 @@ jobs:
       artifact_path: artifacts-${{ needs.prepare.outputs.image_tag }}
 
   release:
-    name: Release
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    name: Server Release
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/tags/helm/') }}
     needs:
       - prepare
       - build
@@ -120,6 +121,17 @@ jobs:
       release_tag: ${{ needs.prepare.outputs.release_tag }}
       artifact_path: artifacts-${{ needs.prepare.outputs.image_tag }}
 
+  helm_release:
+    name: Helm Chart Release
+    if: ${{ startsWith(github.ref, 'refs/tags/helm/') }}
+    needs:
+      - prepare
+      - verify
+    uses: ./.github/workflows/reusable-helm-release.yaml
+    with:
+      image_repo: ghcr.io/agntcy
+      release_tag: ${{ replace(needs.prepare.outputs.release_tag, 'helm/', '') }}
+
   success:
     name: Success
     # https://github.com/actions/runner/issues/2566
@@ -129,7 +141,8 @@ jobs:
       - prepare
       - build
       - test
-      - release
+      - release # This job might be skipped
+      - helm_release # This job might be skipped
     runs-on: ubuntu-latest
     steps:
       - name: Echo Success

--- a/.github/workflows/reusable-helm-release.yaml
+++ b/.github/workflows/reusable-helm-release.yaml
@@ -1,0 +1,67 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Helm Chart Release
+
+on:
+  workflow_call:
+    inputs:
+      image_repo:
+        required: true
+        type: string
+        description: "Image repo to use."
+      release_tag:
+        required: true
+        type: string
+        description: "Release tag for the Helm chart."
+      helm-version:
+        required: false
+        default: "3.12.1"
+        type: string
+        description: "Helm version to use."
+
+jobs:
+  chart:
+    name: Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: notused
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814  # v4.2.0
+        with:
+          version: ${{ inputs.helm-version }}
+
+      - name: Helm update dependencies
+        shell: bash
+        run: helm dependency update install/charts/oasf
+
+      - name: Helm lint
+        shell: bash
+        run: helm lint install/charts/oasf --with-subcharts
+
+      - name: Set chart name
+        id: chart-name
+        shell: bash
+        run: echo "value=${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Helm package
+        shell: bash
+        run: |
+          helm package install/charts/oasf --dependency-update --version ${{ inputs.release_tag }}
+
+      - name: Helm push to GHCR OCI registry
+        shell: bash
+        run: |
+          echo "🚧 Pushing ${{ inputs.release_tag }} to GHCR OCI registry"
+          helm push ${{ steps.chart-name.outputs.value }}-${{ inputs.release_tag }}.tgz oci://${{ inputs.image_repo }}/oasf/helm-charts

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -1,7 +1,7 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-name: Release
+name: Server Release
 
 on:
   workflow_call:
@@ -22,11 +22,6 @@ on:
         required: true
         type: string
         description: "Path from where to download image artifacts."
-      helm-version:
-        required: false
-        default: "3.12.1"
-        type: string
-        description: 'Helm version'
 
 jobs:
   images:
@@ -72,51 +67,6 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           task release -y
-
-  chart:
-    name: Helm chart
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
-        with:
-          fetch-depth: 0
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: notused
-          password: ${{ secrets.GITHUB_TOKEN  }}
-
-      - name: Setup Helm
-        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814  # v4.2.0
-        with:
-          version: ${{ inputs.helm-version }}
-
-      - name: Helm update
-        shell: bash
-        run: helm dependency update install/charts/oasf
-
-      - name: Helm lint
-        shell: bash
-        run: helm lint install/charts/oasf --with-subcharts
-
-      - name: Set chart name
-        id: chart-name
-        shell: bash
-        run: echo "value=${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
-
-      - name: Helm package
-        shell: bash
-        run: |
-          helm package install/charts/oasf --dependency-update --version ${{ inputs.release_tag }}
-
-      - name: Helm push to GHCR OCI registry
-        shell: bash
-        run: |
-          echo "🚧 Pushing ${{ inputs.release_tag }} to GHCR OCI registry"
-          helm push ${{ steps.chart-name.outputs.value }}-${{ inputs.release_tag }}.tgz oci://${{ inputs.image_repo }}/oasf/helm-charts
 
   release:
     name: Release


### PR DESCRIPTION
Release helm chart separately with helm/vX.X.X tag. So if the helm chart needs to be changed separately, there is no need to release the server, and a new chart won't get released with each OASF release.

Since with one Helm chart multiple OASF versions can be deployed at once, there is no need to release the server and the Helm chart together anymore.

Fixes #189 