### PR TITLE
fix: json schema generator

### DIFF
--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -378,7 +378,7 @@ defmodule Schema.Cache do
             Map.new()
           )
 
-        Map.put(entity_ex, :objects, Map.to_list(ref_entities))
+        Map.put(entity_ex, :entities, Map.to_list(ref_entities))
     end
   end
 

--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -556,12 +556,13 @@ defmodule Schema.Cache do
 
     classes =
       classes
-      # remove intermediate hidden classes
-      |> Stream.filter(fn {class_key, class} -> !hidden_class?(class_key, class) end)
       |> add_class_family(class_family)
       |> Enum.into(%{}, fn class_tuple ->
         enrich_class(class_tuple, categories_attributes, classes, version)
       end)
+      |> Utils.update_classes()
+      # remove intermediate hidden classes
+      |> Stream.filter(fn {class_key, class} -> !hidden_class?(class_key, class) end)
 
     {classes, all_classes, categories}
   end

--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -375,7 +375,8 @@ defmodule Schema.Cache do
             skills,
             domains,
             features,
-            Map.new()
+            Map.new(),
+            entity[:is_enum] || false
           )
 
         Map.put(entity_ex, :entities, Map.to_list(ref_entities))
@@ -407,8 +408,17 @@ defmodule Schema.Cache do
     end)
   end
 
-  defp enrich_ex(type, dictionary_attributes, objects, skills, domains, features, ref_objects) do
-    {attributes, ref_objects} =
+  defp enrich_ex(
+         type,
+         dictionary_attributes,
+         objects,
+         skills,
+         domains,
+         features,
+         ref_entities,
+         is_enum
+       ) do
+    {attributes, ref_entities} =
       update_attributes_ex(
         type[:attributes],
         dictionary_attributes,
@@ -416,10 +426,40 @@ defmodule Schema.Cache do
         skills,
         domains,
         features,
-        ref_objects
+        ref_entities
       )
 
-    {Map.put(type, :attributes, attributes), ref_objects}
+    enriched_type =
+      type
+      |> Map.put(:attributes, attributes)
+      |> (fn map -> if is_enum, do: Map.put(map, :is_enum, true), else: map end).()
+
+    enriched_children =
+      if is_enum do
+        Enum.into(type[:_children] || %{}, %{}, fn {key, child} ->
+          {enriched_child, ref_entities} =
+            enrich_ex(
+              child,
+              dictionary_attributes,
+              objects,
+              skills,
+              domains,
+              features,
+              Map.new(),
+              child[:is_enum] || false
+            )
+
+          enriched_child = Map.put(enriched_child, :entities, Map.to_list(ref_entities))
+
+          {key, enriched_child}
+        end)
+      else
+        type[:_children] || %{}
+      end
+
+    enriched_type = Map.put(enriched_type, :_children, enriched_children)
+
+    {enriched_type, ref_entities}
   end
 
   defp update_attributes_ex(
@@ -429,9 +469,9 @@ defmodule Schema.Cache do
          skills,
          domains,
          features,
-         ref_objects
+         ref_entities
        ) do
-    Enum.map_reduce(attributes, ref_objects, fn {name, attribute}, acc ->
+    Enum.map_reduce(attributes, ref_entities, fn {name, attribute}, acc ->
       reference =
         if Map.has_key?(attribute, :reference) do
           String.to_atom(attribute[:reference])
@@ -481,7 +521,8 @@ defmodule Schema.Cache do
                 skills,
                 domains,
                 features,
-                Map.put(acc, entity_name, nil)
+                Map.put(acc, entity_name, nil),
+                attribute[:is_enum] || false
               )
             end,
             acc
@@ -501,8 +542,8 @@ defmodule Schema.Cache do
       if Map.has_key?(acc, entity_name) do
         acc
       else
-        {object, acc} = enrich.(entity_name)
-        Map.put(acc, entity_name, object)
+        {entity, acc} = enrich.(entity_name)
+        Map.put(acc, entity_name, entity)
       end
 
     {{name, attribute}, acc}

--- a/server/lib/schema/graph.ex
+++ b/server/lib/schema/graph.ex
@@ -14,7 +14,7 @@ defmodule Schema.Graph do
     %{
       nodes: build_nodes(class),
       edges: build_edges(class) |> Enum.uniq(),
-      class: Map.delete(class, :attributes) |> Map.delete(:objects) |> Map.delete(:_links)
+      class: Map.delete(class, :attributes) |> Map.delete(:entities) |> Map.delete(:_links)
     }
   end
 
@@ -29,7 +29,7 @@ defmodule Schema.Graph do
   end
 
   defp build_nodes(nodes, class) do
-    Map.get(class, :objects)
+    Map.get(class, :entities)
     |> Enum.reduce(nodes, fn {_name, obj}, acc ->
       node = %{
         id: make_id(obj.name, obj[:extension]),
@@ -58,7 +58,7 @@ defmodule Schema.Graph do
   end
 
   defp build_edges(class) do
-    objects = Map.new(class.objects)
+    objects = Map.new(class.entities)
     build_edges([], class, objects)
   end
 

--- a/server/lib/schema/json_schema.ex
+++ b/server/lib/schema/json_schema.ex
@@ -43,7 +43,7 @@ defmodule Schema.JsonSchema do
     |> Map.put("properties", properties)
     |> Map.put("additionalProperties", false)
     |> put_required(required)
-    |> encode_objects(type[:objects])
+    |> encode_entities(type[:entities])
     |> empty_object(properties)
   end
 
@@ -110,19 +110,19 @@ defmodule Schema.JsonSchema do
     Map.put(map, "required", Enum.sort(required))
   end
 
-  defp encode_objects(schema, nil) do
+  defp encode_entities(schema, nil) do
     schema
   end
 
-  defp encode_objects(schema, []) do
+  defp encode_entities(schema, []) do
     schema
   end
 
-  defp encode_objects(schema, objects) do
+  defp encode_entities(schema, entities) do
     defs =
-      Enum.into(objects, %{}, fn {name, object} ->
+      Enum.into(entities, %{}, fn {name, entity} ->
         key = Atom.to_string(name) |> String.replace("/", "_")
-        {key, encode(object)}
+        {key, encode_entity(entity, false)}
       end)
 
     Map.put(schema, "$defs", defs)

--- a/server/lib/schema/json_schema.ex
+++ b/server/lib/schema/json_schema.ex
@@ -149,6 +149,12 @@ defmodule Schema.JsonSchema do
     {Map.new(properties), required}
   end
 
+  defp encode_attribute(_name, "string_map_t", attr) do
+    new_schema(attr)
+    |> Map.put("type", "object")
+    |> Map.put("additionalProperties", %{"type" => "string"})
+  end
+
   defp encode_attribute(_name, "integer_t", attr) do
     new_schema(attr) |> encode_integer(attr)
   end

--- a/server/lib/schema/profiles.ex
+++ b/server/lib/schema/profiles.ex
@@ -21,7 +21,7 @@ defmodule Schema.Profiles do
     Map.update!(class, :attributes, fn attributes ->
       apply_profiles(attributes, profiles, size)
     end)
-    |> Map.update!(:objects, fn objects ->
+    |> Map.update!(:entities, fn objects ->
       Enum.map(objects, fn {name, object} ->
         {name,
          Map.update!(object, :attributes, fn attributes ->

--- a/server/lib/schema/repo.ex
+++ b/server/lib/schema/repo.ex
@@ -309,11 +309,6 @@ defmodule Schema.Repo do
     Agent.get(__MODULE__, fn schema -> Cache.feature(schema, id) end)
   end
 
-  @spec feature_ex(atom) :: nil | Cache.class_t()
-  def feature_ex(id) do
-    Agent.get(__MODULE__, fn schema -> Cache.entity_ex(schema, :feature, id) end)
-  end
-
   @spec objects() :: map()
   def objects() do
     Agent.get(__MODULE__, fn schema -> Cache.objects(schema) end)

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -92,6 +92,27 @@ defmodule Schema.Utils do
     |> define_datetime_attributes()
   end
 
+  @spec update_classes(map()) :: map()
+  def update_classes(classes) do
+    Enum.into(classes, %{}, fn {name, class} ->
+      children =
+        find_children(classes, Atom.to_string(name))
+        |> Enum.map(fn child ->
+          child
+          |> Map.put(:class_name, child[:caption])
+          |> Map.put(:type, Atom.to_string(:class_t))
+          |> Map.put(:class_type, child[:name])
+        end)
+        |> Enum.into(%{}, fn child ->
+          {child.name, child}
+        end)
+
+      class
+      |> Map.put(:_children, children)
+      |> (&{name, &1}).()
+    end)
+  end
+
   @spec update_objects(map(), map()) :: map()
   def update_objects(objects, dictionary) do
     Enum.into(objects, %{}, fn {name, object} ->

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -734,7 +734,7 @@ defmodule SchemaWeb.SchemaController do
 
     default_version = %{
       :version => Schema.version(),
-      :url => "#{base_url}/#{Schema.version()}/api"
+      :url => "#{base_url}/api/#{Schema.version()}"
     }
 
     versions_response =

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -2916,7 +2916,7 @@ defmodule SchemaWeb.SchemaController do
     objects = update_objects(Map.new(), data[:attributes])
 
     if map_size(objects) > 0 do
-      Map.put(data, :objects, objects)
+      Map.put(data, :entities, objects)
     else
       data
     end


### PR DESCRIPTION
Fixed the json draft-07 schema generator, so it handles class types and enum entities. 

- In case of an enum entity it lists the options them in a `oneOf` list
- In case of the record's `extension` attribute it only validates against the OASF features if the name matches with one of them. 
- In case of skills it only accepts skills from OASF.
- object definitions are grouped by object/class family

To try it out online:
1. Visit https://www.jsonschemavalidator.net
2. Navigate to a class/object on OASF UI, and generate the json schema (top right corner, `Schemas` -> `JSON Schema`), paste it into the left pane of the online validator
3. Generate a sample (top right corner, `Schemas` -> `Sample`) and paste it into the right pane of the online validator
4. It should be valid. Try and make it invalid to see what happens.

Fixes #167 
Fixes #134 