### PR TITLE
ci: fix Helm release tag calculation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,10 +127,18 @@ jobs:
     needs:
       - prepare
       - verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate Helm Release Tag
+        id: calculate_helm_tag
+        run: |
+          RAW_RELEASE_TAG="${{ needs.prepare.outputs.release_tag }}"
+          HELM_RELEASE_TAG="${RAW_RELEASE_TAG#helm/}"
+          echo "helm_release_tag=$HELM_RELEASE_TAG" >> "$GITHUB_OUTPUT"
     uses: ./.github/workflows/reusable-helm-release.yaml
     with:
       image_repo: ghcr.io/agntcy
-      release_tag: ${{ replace(needs.prepare.outputs.release_tag, 'helm/', '') }}
+      release_tag: ${{ steps.calculate_helm_tag.outputs.helm_release_tag }}
 
   success:
     name: Success


### PR DESCRIPTION
Fixed a regression in the ci.yaml file that made it invalid.

Fixes #222 