### PR TITLE
feat: link domains with record object

### DIFF
--- a/proto/objects/v3/domain.proto
+++ b/proto/objects/v3/domain.proto
@@ -1,0 +1,19 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package objects.v3;
+
+// A specific domain under which the record can operate in.
+// Supported domains: https://schema.oasf.agntcy.org/domains
+message Domain {
+  // UID of the domain in format: schema.oasf.agntcy.org/domains/<domain-name>
+  string name = 1;
+
+  // Unique identifier of the domain.
+  uint32 id = 2;
+
+  // Metadata associated with the domain.
+  map<string, string> annotations = 3;
+}

--- a/proto/objects/v3/record.proto
+++ b/proto/objects/v3/record.proto
@@ -9,6 +9,7 @@ import "objects/v3/extension.proto";
 import "objects/v3/locator.proto";
 import "objects/v3/signature.proto";
 import "objects/v3/skill.proto";
+import "objects/v3/domain.proto";
 
 // Record defines a schema for versioned AI agentic content representation.
 // The schema provides a way to describe an agentic record in a structured format.
@@ -58,6 +59,9 @@ message Record {
 
   // Security signature of the record.
   Signature signature = 11;
+
+  // List of domains under which the record can operate in.
+  repeated Domain domains = 12;
 
   // Reference to the previous record, if any.
   // Used to link the record to its previous versions.

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -186,6 +186,23 @@
       "description": "The digest of the targeted content, conforming to the requirements. Retrieved content SHOULD be verified against this digest when consumed via untrusted sources. The digest property acts as a content identifier, enabling content addressability. It uniquely identifies content by taking a collision-resistant hash of the bytes. If the digest can be communicated in a secure manner, one can verify content from an insecure source by recalculating the digest independently, ensuring the content has not been modified. The value of the digest property is a string consisting of an algorithm portion and an encoded portion. The algorithm specifies the cryptographic hash function and encoding used for the digest; the encoded portion contains the encoded result of the hash function. A digest MUST be calculated for all properties except the digest itself which MUST be ignored during the calculation. The model SHOULD then be updated with the calculated digest.",
       "type": "file_hash_t"
     },
+    "domain": {
+      "caption": "Domain",
+      "description": "A domain that applies to an agent.",
+      "type": "class_t",
+      "class_type": "base_domain",
+      "family": "domain",
+      "is_enum": true
+    },
+    "domains": {
+      "caption": "Domains",
+      "description": "Domains that the agent can operate in.",
+      "type": "class_t",
+      "class_type": "base_domain",
+      "family": "domain",
+      "is_enum": true,
+      "is_array": true
+    },
     "env_deps": {
       "caption": "Values for Dependencies",
       "description": "List of environment variable values to be set for the agent dependencies.",
@@ -538,7 +555,7 @@
     },
     "skill": {
       "caption": "Skill",
-      "description": "A skill that apply to an agent.",
+      "description": "A skill that applies to an agent.",
       "type": "class_t",
       "class_type": "base_skill",
       "family": "skill",

--- a/schema/objects/record.json
+++ b/schema/objects/record.json
@@ -44,6 +44,11 @@
       "description": "List of skills associated with this record.",
       "requirement": "required"
     },
+    "domains": {
+      "caption": "Domains",
+      "description": "List of domains associated with this record.",
+      "requirement": "required"
+    },
     "locators": {
       "caption": "Locators",
       "description": "List of source locators where this record can be found or used from.",


### PR DESCRIPTION
This PR links domains with the record object to enable usage of domains for the schema on OASF side, as well as announcement and discovery on the Directory side.