### PR TITLE
fix: update post-migration OASF web links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Choose a **unique** field you want to add, `uid` in the example above and popula
     3. Specific description of `uid` in the `agent` object -
         1. `uid` : `Unique Identifier/s of the reported agent."`
 3. `type` → Review OASF data_types and ensure you utilize appropriate types while defining new fields.
-    1. All the available data_types can be accessed [here](https://schema.oasf.agntcy.org/data_types).
+    1. All the available data_types can be accessed [here](https://schema.oasf.outshift.com/data_types).
     2. They are also accessible in your local instance of the oasf server - http://localhost:8000/data_types
 4. `is_array` → This a boolean key:value pair that you would need to add if the field you are defining is an array.
     1. e.g. `"is_array": true`
@@ -155,7 +155,7 @@ An example `locator.json` object file,
         }
         ```
 
-**Note:** If you want to create an object which would act only as a base for other objects, you must prefix the object `name` and the actual `json` filename with an `_`. The resultant object will not be visible in the [OASF Server.](https://schema.oasf.agntcy.org/objects) For example, take a look at the [entity](https://github.com/agntcy/oasf/blob/main/schema/objects/_entity.json) object.
+**Note:** If you want to create an object which would act only as a base for other objects, you must prefix the object `name` and the actual `json` filename with an `_`. The resultant object will not be visible in the [OASF Server.](https://schema.oasf.outshift.com/objects) For example, take a look at the [entity](https://github.com/agntcy/oasf/blob/main/schema/objects/_entity.json) object.
 
 Sample entry in the `dictionary.json`,
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The server/ directory contains the Open Agents Schema Framework (OASF) Schema Se
 The schema server is an HTTP server that provides a convenient way to browse and use the OASF schema.
 The server provides also schema validation capabilities to be used during development.
 
-You can access the OASF schema server, which is running the latest released schema, at [schema.oasf.agntcy.org](https://schema.oasf.agntcy.org).
+You can access the OASF schema server, which is running the latest released schema, at [schema.oasf.outshift.com](https://schema.oasf.outshift.com).
 
 The schema server can also be used locally.
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,7 +1,7 @@
 # OASF
 
 This repository contains the protocol definitions and language stubs for the
-[Open Agentic Schema Framework](https://schema.oasf.agntcy.org).
+[Open Agentic Schema Framework](https://schema.oasf.outshift.com).
 
 ## Compatibility matrix
 

--- a/proto/objects/v1/skill.proto
+++ b/proto/objects/v1/skill.proto
@@ -6,9 +6,6 @@ syntax = "proto3";
 package objects.v1;
 
 // A specific skills that an agent is capable of performing.
-// Specs: https://schema.oasf.agntcy.org/skills.
-//
-// Example (https://schema.oasf.agntcy.org/skills/contextual_comprehension)
 message Skill {
   // Additional metadata for this skill.
   map<string, string> annotations = 1;

--- a/proto/objects/v2/extension.proto
+++ b/proto/objects/v2/extension.proto
@@ -13,7 +13,6 @@ import "google/protobuf/struct.proto";
 message Extension {
   // Name of the extension.
   // Can be used as a fully qualified name.
-  // For example, "org.agntcy.oasf.schema/features/<feature-name>"
   string name = 1;
 
   // Version of the extension.

--- a/proto/objects/v2/skill.proto
+++ b/proto/objects/v2/skill.proto
@@ -6,9 +6,8 @@ syntax = "proto3";
 package objects.v2;
 
 // A specific skills that an agent record is capable of performing.
-// Supported skills: https://schema.oasf.agntcy.org/skills
 message Skill {
-  // UID of the skill in format: org.agntcy.oasf.schema/skills/<skill-name>
+  // Unique name of the skill.
   string name = 1;
 
   // Unique identifier of the skill.

--- a/proto/objects/v3/extension.proto
+++ b/proto/objects/v3/extension.proto
@@ -13,7 +13,6 @@ import "google/protobuf/struct.proto";
 message Extension {
   // Name of the extension.
   // Can be used as a fully qualified name.
-  // For example, "org.agntcy.oasf.schema/features/<feature-name>"
   string name = 1;
 
   // Version of the extension.

--- a/proto/objects/v3/skill.proto
+++ b/proto/objects/v3/skill.proto
@@ -6,9 +6,8 @@ syntax = "proto3";
 package objects.v3;
 
 // A specific skills that a record is capable of performing.
-// Supported skills: https://schema.oasf.agntcy.org/skills
 message Skill {
-  // UID of the skill in format: org.agntcy.oasf.schema/skills/<skill-name>
+  // Unique name of the skill.
   string name = 1;
 
   // Unique identifier of the skill.

--- a/schema/features/base_feature.json
+++ b/schema/features/base_feature.json
@@ -5,23 +5,23 @@
   "name": "base_feature",
   "attributes": {
     "name": {
-      "description": "The agent extension name.",
+      "description": "The name as a unique identifier of the extension.",
       "requirement": "required"
     },
     "version": {
       "caption": "Version",
-      "description": "The agent extension version. For example: <code>1.0.0-alpha.2</code>.",
+      "description": "The version of the extension. For example: <code>1.0.0-alpha.2</code>.",
       "requirement": "optional"
     },
     "annotations": {
       "caption": "Annotations",
-      "description": "Additional metadata associated with the agent extension.",
+      "description": "Additional metadata associated with the extension.",
       "requirement": "optional"
     },
     "data": {
       "reference": "extension_data",
       "caption": "Data",
-      "description": "The data associated with the agent extension.",
+      "description": "The data associated with the extension.",
       "requirement": "required"
     }
   }

--- a/schema/features/base_feature.json
+++ b/schema/features/base_feature.json
@@ -5,7 +5,7 @@
   "name": "base_feature",
   "attributes": {
     "name": {
-      "description": "The agent extension name. For example: <code>schema.oasf.agntcy.org/features/observability</code>.",
+      "description": "The agent extension name.",
       "requirement": "required"
     },
     "version": {

--- a/schema/metaschema/attribute.schema.json
+++ b/schema/metaschema/attribute.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schema.oasf.agntcy.org/attribute.schema.json",
+  "$id": "https://schema.oasf.outshift.com/attribute.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Attribute",
   "type": "object",

--- a/schema/metaschema/categories.schema.json
+++ b/schema/metaschema/categories.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/categories.schema.json",
+    "$id": "https://schema.oasf.outshift.com/categories.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Categories",
     "description": "The OASF categories organize agent skill, domain or feature classes, each aligned with a specific domain or area of focus.",

--- a/schema/metaschema/class.schema.json
+++ b/schema/metaschema/class.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/class.schema.json",
+    "$id": "https://schema.oasf.outshift.com/class.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Class",
     "description": "Classes are particular sets of attributes and objects representing aspects of an Agent.",

--- a/schema/metaschema/common-class-object.schema.json
+++ b/schema/metaschema/common-class-object.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schema.oasf.agntcy.org/common-class-object.schema.json",
+  "$id": "https://schema.oasf.outshift.com/common-class-object.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Object",
   "description": "Common metaschema shared between objects and classes.",

--- a/schema/metaschema/deprecated.schema.json
+++ b/schema/metaschema/deprecated.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/deprecated.schema.json",
+    "$id": "https://schema.oasf.outshift.com/deprecated.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Deprecated",
     "type": "object",

--- a/schema/metaschema/dictionary-attribute.schema.json
+++ b/schema/metaschema/dictionary-attribute.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/dictionary-attribute.schema.json",
+    "$id": "https://schema.oasf.outshift.com/dictionary-attribute.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Dictionary Attribute",
     "type": "object",

--- a/schema/metaschema/dictionary.schema.json
+++ b/schema/metaschema/dictionary.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/dictionary.schema.json",
+    "$id": "https://schema.oasf.outshift.com/dictionary.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Dictionary",
     "description": "An attribute dictionary of all available attributes and their types. Classes are particular sets of attributes from the dictionary.",

--- a/schema/metaschema/enum.schema.json
+++ b/schema/metaschema/enum.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/enum.schema.json",
+    "$id": "https://schema.oasf.outshift.com/enum.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Enumeration",
     "description": "An enumeration of options for an attribute.",

--- a/schema/metaschema/extension.schema.json
+++ b/schema/metaschema/extension.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/extension.schema.json",
+    "$id": "https://schema.oasf.outshift.com/extension.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Extension",
     "description": "Extensions allow the schema to be extended using the framework without modification of the core schema. New attributes, objects, Classes, categories and profiles are all available to extensions.",

--- a/schema/metaschema/object.schema.json
+++ b/schema/metaschema/object.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schema.oasf.agntcy.org/object.schema.json",
+  "$id": "https://schema.oasf.outshift.com/object.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Object",
   "description": "An object is a collection of contextually related attributes, usually representing an entity, and may include other objects. Each object is also a data type in OASF. Examples of object data types are Process, Device, User, Malware, and File.",

--- a/schema/metaschema/profile.schema.json
+++ b/schema/metaschema/profile.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/profile.schema.json",
+    "$id": "https://schema.oasf.outshift.com/profile.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Profile",
     "description": "Profiles are overlays on classes and objects, effectively a dynamic mix-in class of attributes with their requirements and constraints.",

--- a/schema/metaschema/references.schema.json
+++ b/schema/metaschema/references.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/references.schema.json",
+    "$id": "https://schema.oasf.outshift.com/references.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "References",
     "description": "A list of references. A reference is a hyperlink to an associated definition for the current item (attribute, class, or object).",

--- a/schema/metaschema/semver.schema.json
+++ b/schema/metaschema/semver.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.oasf.agntcy.org/semver.schema.json",
+    "$id": "https://schema.oasf.outshift.com/semver.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "string",
     "minLength": 5,

--- a/server/lib/schema/json_schema.ex
+++ b/server/lib/schema/json_schema.ex
@@ -9,7 +9,7 @@ defmodule Schema.JsonSchema do
   alias Schema.Utils
   alias Schema.Types
 
-  @schema_base_uri "https://schema.oasf.agntcy.org/schema"
+  @schema_base_uri "https://schema.oasf.outshift.com/schema"
   @schema_version "http://json-schema.org/draft-07/schema#"
 
   @doc """

--- a/server/lib/schema/types.ex
+++ b/server/lib/schema/types.ex
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Schema.Types do
-  @schema_uri "org.agntcy.oasf"
+  @schema_uri "org.agntcy.oasf.schema"
 
   @moduledoc """
   Schema types and helpers functions to make unique identifiers.

--- a/server/lib/schema/types.ex
+++ b/server/lib/schema/types.ex
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Schema.Types do
-  @schema_uri "org.agntcy.oasf.schema"
+  @schema_uri "schema.oasf.agntcy.org"
 
   @moduledoc """
   Schema types and helpers functions to make unique identifiers.

--- a/server/lib/schema/types.ex
+++ b/server/lib/schema/types.ex
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Schema.Types do
-  @schema_addr "schema.oasf.agntcy.org"
+  @schema_uri "org.agntcy.oasf"
 
   @moduledoc """
   Schema types and helpers functions to make unique identifiers.
@@ -48,10 +48,10 @@ defmodule Schema.Types do
   Makes longer class name from class type/family, category and name.
   """
   def long_class_name(family, name) do
-    "#{@schema_addr}/#{family}s/#{name}"
+    "#{@schema_uri}/#{family}s/#{name}"
   end
 
   def is_oasf_class?(name) do
-    String.starts_with?(name, @schema_addr)
+    String.starts_with?(name, @schema_uri)
   end
 end

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -366,7 +366,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 10101,
-            name: "schema.oasf.agntcy.org/skills/contextual_comprehension"
+            name: "org.agntcy.oasf/skills/contextual_comprehension"
           })
         end,
       Domain:
@@ -386,7 +386,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 101,
-            name: "schema.oasf.agntcy.org/domains/technology"
+            name: "org.agntcy.oasf/domains/technology"
           })
         end,
       Feature:
@@ -421,7 +421,7 @@ defmodule SchemaWeb.SchemaController do
               },
               export_format: "csv"
             },
-            name: "schema.oasf.agntcy.org/features/observability",
+            name: "org.agntcy.oasf/features/observability",
             version: "v0.2.2"
           })
         end,
@@ -502,11 +502,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 10101,
-                name: "schema.oasf.agntcy.org/skills/contextual_comprehension"
+                name: "org.agntcy.oasf/skills/contextual_comprehension"
               },
               %{
                 id: 10203,
-                name: "schema.oasf.agntcy.org/skills/paraphrasing"
+                name: "org.agntcy.oasf/skills/paraphrasing"
               }
             ]
           })
@@ -567,11 +567,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 101,
-                name: "schema.oasf.agntcy.org/domains/internet_of_things"
+                name: "org.agntcy.oasf/domains/internet_of_things"
               },
               %{
                 id: 403,
-                name: "schema.oasf.agntcy.org/domains/fraud_prevention"
+                name: "org.agntcy.oasf/domains/fraud_prevention"
               }
             ]
           })
@@ -642,7 +642,7 @@ defmodule SchemaWeb.SchemaController do
                   },
                   export_format: "csv"
                 },
-                name: "schema.oasf.agntcy.org/features/observability",
+                name: "org.agntcy.oasf/features/observability",
                 version: "v0.2.2"
               }
             ]

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -366,7 +366,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 10101,
-            name: "org.agntcy.oasf.schema/skills/contextual_comprehension"
+            name: "schema.oasf.agntcy.org/skills/contextual_comprehension"
           })
         end,
       Domain:
@@ -386,7 +386,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 101,
-            name: "org.agntcy.oasf.schema/domains/technology"
+            name: "schema.oasf.agntcy.org/domains/technology"
           })
         end,
       Feature:
@@ -421,7 +421,7 @@ defmodule SchemaWeb.SchemaController do
               },
               export_format: "csv"
             },
-            name: "org.agntcy.oasf.schema/features/observability",
+            name: "schema.oasf.agntcy.org/features/observability",
             version: "v0.2.2"
           })
         end,
@@ -502,11 +502,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 10101,
-                name: "org.agntcy.oasf.schema/skills/contextual_comprehension"
+                name: "schema.oasf.agntcy.org/skills/contextual_comprehension"
               },
               %{
                 id: 10203,
-                name: "org.agntcy.oasf.schema/skills/paraphrasing"
+                name: "schema.oasf.agntcy.org/skills/paraphrasing"
               }
             ]
           })
@@ -567,11 +567,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 101,
-                name: "org.agntcy.oasf.schema/domains/internet_of_things"
+                name: "schema.oasf.agntcy.org/domains/internet_of_things"
               },
               %{
                 id: 403,
-                name: "org.agntcy.oasf.schema/domains/fraud_prevention"
+                name: "schema.oasf.agntcy.org/domains/fraud_prevention"
               }
             ]
           })
@@ -642,7 +642,7 @@ defmodule SchemaWeb.SchemaController do
                   },
                   export_format: "csv"
                 },
-                name: "org.agntcy.oasf.schema/features/observability",
+                name: "schema.oasf.agntcy.org/features/observability",
                 version: "v0.2.2"
               }
             ]

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -366,7 +366,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 10101,
-            name: "org.agntcy.oasf/skills/contextual_comprehension"
+            name: "org.agntcy.oasf.schema/skills/contextual_comprehension"
           })
         end,
       Domain:
@@ -386,7 +386,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 101,
-            name: "org.agntcy.oasf/domains/technology"
+            name: "org.agntcy.oasf.schema/domains/technology"
           })
         end,
       Feature:
@@ -421,7 +421,7 @@ defmodule SchemaWeb.SchemaController do
               },
               export_format: "csv"
             },
-            name: "org.agntcy.oasf/features/observability",
+            name: "org.agntcy.oasf.schema/features/observability",
             version: "v0.2.2"
           })
         end,
@@ -502,11 +502,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 10101,
-                name: "org.agntcy.oasf/skills/contextual_comprehension"
+                name: "org.agntcy.oasf.schema/skills/contextual_comprehension"
               },
               %{
                 id: 10203,
-                name: "org.agntcy.oasf/skills/paraphrasing"
+                name: "org.agntcy.oasf.schema/skills/paraphrasing"
               }
             ]
           })
@@ -567,11 +567,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 101,
-                name: "org.agntcy.oasf/domains/internet_of_things"
+                name: "org.agntcy.oasf.schema/domains/internet_of_things"
               },
               %{
                 id: 403,
-                name: "org.agntcy.oasf/domains/fraud_prevention"
+                name: "org.agntcy.oasf.schema/domains/fraud_prevention"
               }
             ]
           })
@@ -642,7 +642,7 @@ defmodule SchemaWeb.SchemaController do
                   },
                   export_format: "csv"
                 },
-                name: "org.agntcy.oasf/features/observability",
+                name: "org.agntcy.oasf.schema/features/observability",
                 version: "v0.2.2"
               }
             ]


### PR DESCRIPTION
This PR updates the OASF links due to migration to the new domain under [schema.oasf.outshift.com](https://schema.oasf.outshift.com). 