### PR TITLE
fix: hidden classes on the UI

### DIFF
--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -106,20 +106,26 @@ defmodule Schema.Cache do
     # Missing description warnings, datetime attributes, and profiles
     objects =
       objects
-      |> Utils.update_objects(dictionary_attributes)
+      |> Utils.update_objects(all_objects, dictionary_attributes)
       |> update_objects()
       |> final_check(dictionary_attributes)
 
     skills =
-      update_classes(skills, objects)
+      skills
+      |> Utils.update_classes(all_skills)
+      |> update_classes(objects)
       |> final_check(dictionary_attributes)
 
     domains =
-      update_classes(domains, objects)
+      domains
+      |> Utils.update_classes(all_domains)
+      |> update_classes(objects)
       |> final_check(dictionary_attributes)
 
     features =
-      update_classes(features, objects)
+      features
+      |> Utils.update_classes(all_features)
+      |> update_classes(objects)
       |> final_check(dictionary_attributes)
 
     base_class = final_check(:base_class, base_class, dictionary_attributes)
@@ -597,13 +603,12 @@ defmodule Schema.Cache do
 
     classes =
       classes
+      # remove intermediate hidden classes
+      |> Stream.filter(fn {class_key, class} -> !hidden_class?(class_key, class) end)
       |> add_class_family(class_family)
       |> Enum.into(%{}, fn class_tuple ->
         enrich_class(class_tuple, categories_attributes, classes, version)
       end)
-      |> Utils.update_classes()
-      # remove intermediate hidden classes
-      |> Stream.filter(fn {class_key, class} -> !hidden_class?(class_key, class) end)
 
     {classes, all_classes, categories}
   end

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -882,6 +882,7 @@ defmodule Schema.Generator do
       if field[:is_enum] do
         # Filter to include only children classes that are not hidden
         Utils.find_children(all_classes_fn, field[:class_type])
+        |> Enum.reject(fn item -> item[:hidden?] == true end)
         |> Enum.map(&class_fn.(&1.name))
         |> Enum.filter(&(&1 != nil))
       else
@@ -900,7 +901,8 @@ defmodule Schema.Generator do
   defp get_valid_object(field) do
     valid_objects =
       if field[:is_enum] do
-        Utils.find_children(Schema.objects(), field[:object_type])
+        Utils.find_children(Schema.all_objects(), field[:object_type])
+        |> Enum.reject(fn item -> item[:hidden?] == true end)
         |> Enum.map(fn descendant ->
           descendant[:name]
           |> String.to_atom()

--- a/server/lib/schema/json_schema.ex
+++ b/server/lib/schema/json_schema.ex
@@ -258,7 +258,9 @@ defmodule Schema.JsonSchema do
     type = attr[:object_type]
 
     if attr[:is_enum] do
-      children_objects = Utils.find_children(Schema.objects(), type)
+      children_objects =
+        Utils.find_children(Schema.all_objects(), type)
+        |> Enum.reject(fn item -> item[:hidden?] == true end)
 
       refs =
         Enum.map(children_objects, fn item -> %{"$ref" => make_object_ref(item[:name])} end)
@@ -282,7 +284,9 @@ defmodule Schema.JsonSchema do
           _ -> schema
         end
 
-      children_classes = Utils.find_children(all_classes_fn, type)
+      children_classes =
+        Utils.find_children(all_classes_fn, type)
+        |> Enum.reject(fn item -> item[:hidden?] == true end)
 
       refs =
         if family == "feature" do

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -92,17 +92,24 @@ defmodule Schema.Utils do
     |> define_datetime_attributes()
   end
 
-  @spec update_classes(map()) :: map()
-  def update_classes(classes) do
+  @spec update_classes(map(), map()) :: map()
+  def update_classes(classes, all_classes) do
     Enum.into(classes, %{}, fn {name, class} ->
       children =
-        find_children(classes, Atom.to_string(name))
+        find_children(all_classes, Atom.to_string(name))
         |> Enum.map(fn child ->
-          child
-          |> Map.put(:class_name, child[:caption])
-          |> Map.put(:type, Atom.to_string(:class_t))
-          |> Map.put(:class_type, child[:name])
+          case Map.get(classes, String.to_atom(child[:name])) do
+            nil ->
+              nil
+
+            child_class ->
+              child_class
+              |> Map.put(:class_name, child_class[:caption])
+              |> Map.put(:type, Atom.to_string(:class_t))
+              |> Map.put(:class_type, child_class[:name])
+          end
         end)
+        |> Enum.reject(&is_nil/1)
         |> Enum.into(%{}, fn child ->
           {child.name, child}
         end)
@@ -113,19 +120,26 @@ defmodule Schema.Utils do
     end)
   end
 
-  @spec update_objects(map(), map()) :: map()
-  def update_objects(objects, dictionary) do
+  @spec update_objects(map(), map(), map()) :: map()
+  def update_objects(objects, all_objects, dictionary) do
     Enum.into(objects, %{}, fn {name, object} ->
       links = object_links(dictionary, Atom.to_string(name))
 
       children =
-        find_children(objects, Atom.to_string(name))
+        find_children(all_objects, Atom.to_string(name))
         |> Enum.map(fn child ->
-          child
-          |> Map.put(:object_name, child[:caption])
-          |> Map.put(:type, Atom.to_string(:object_t))
-          |> Map.put(:object_type, child[:name])
+          case Map.get(objects, String.to_atom(child[:name])) do
+            nil ->
+              nil
+
+            child_class ->
+              child_class
+              |> Map.put(:object_name, child_class[:caption])
+              |> Map.put(:type, Atom.to_string(:object_t))
+              |> Map.put(:object_type, child_class[:name])
+          end
         end)
+        |> Enum.reject(&is_nil/1)
         |> Enum.into(%{}, fn child ->
           {child.name, child}
         end)

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -572,7 +572,9 @@ defmodule SchemaWeb.PageView do
       if enum do
         case obj[:type] do
           "object_t" ->
-            children = Schema.Utils.find_children(Schema.objects(), obj[:object_type])
+            children =
+              Schema.Utils.find_children(Schema.all_objects(), obj[:object_type])
+              |> Enum.reject(fn item -> item[:hidden?] == true end)
 
             if children != nil and !Enum.empty?(children) do
               [


### PR DESCRIPTION
The schema generator fix introduced a regression: hidden classes were appearing on the UI, because to find the children classes required to include them in the regular skills/domains/features/objects maps.

Now only `all_*` maps are being used to find children so hidden classes/objects can be removed from regular maps so they are not appearing on the UI.

Fixes #219 