### PR TITLE
feat(server, schema): simplified class names

### DIFF
--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -635,7 +635,7 @@ defmodule Schema.Cache do
       |> Stream.filter(fn {class_key, class} -> !hidden_class?(class_key, class) end)
       |> add_class_family(class_family)
       |> Enum.into(%{}, fn class_tuple ->
-        enrich_class(class_tuple, categories_attributes, classes, version)
+        enrich_class(class_tuple, categories_attributes, classes, version, all_classes)
       end)
 
     {classes, all_classes, categories}
@@ -694,12 +694,12 @@ defmodule Schema.Cache do
   end
 
   # Add category_uid, class_uid, and type_uid
-  defp enrich_class({class_key, class}, categories, classes, version) do
+  defp enrich_class({class_key, class}, categories, classes, version, all_classes) do
     class =
       class
       |> update_class_uid(categories, classes)
       |> add_class_uid(class_key)
-      |> add_class_name(class_key)
+      |> add_class_name(class_key, all_classes)
       |> add_schema_version(version)
 
     {class_key, class}
@@ -816,11 +816,11 @@ defmodule Schema.Cache do
     end)
   end
 
-  defp add_class_name(data, name) do
+  defp add_class_name(data, name, all_classes) do
     if is_nil(data[:attributes][:name]) do
       data
     else
-      class_name = Types.long_class_name(data[:family], data[:name])
+      class_name = Types.class_name_with_hierarchy(data[:name], all_classes)
 
       enum = %{
         :caption => data[:caption],

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -118,7 +118,6 @@ defmodule Schema.Generator do
   defp generate_sample_class(class) do
     data =
       generate_sample(class)
-      |> generate_class_name(class)
 
     case data[:activity_id] do
       nil ->
@@ -136,16 +135,6 @@ defmodule Schema.Generator do
         |> put_type_name(uid, class)
         |> Map.delete(:raw_data)
         |> Map.delete(:unmapped)
-    end
-  end
-
-  defp generate_class_name(data, class) do
-    if data[:name] == nil do
-      data
-    else
-      Map.update!(data, :name, fn _name ->
-        Types.long_class_name(class[:family], class[:name])
-      end)
     end
   end
 

--- a/server/lib/schema/json_schema.ex
+++ b/server/lib/schema/json_schema.ex
@@ -289,33 +289,9 @@ defmodule Schema.JsonSchema do
         |> Enum.reject(fn item -> item[:hidden?] == true end)
 
       refs =
-        if family == "feature" do
-          feature_names =
-            Enum.map(children_classes, fn item ->
-              Types.long_class_name(family, item[:name])
-            end)
-
-          Enum.map(children_classes, fn item ->
-            %{"$ref" => make_class_ref(family, item[:name])}
-          end) ++
-            [
-              %{
-                "type" => "object",
-                "properties" => %{
-                  "name" => %{"type" => "string"}
-                },
-                "not" => %{
-                  "properties" => %{
-                    "name" => %{"enum" => feature_names}
-                  }
-                }
-              }
-            ]
-        else
-          Enum.map(children_classes, fn item ->
-            %{"$ref" => make_class_ref(family, item[:name])}
-          end)
-        end
+        Enum.map(children_classes, fn item ->
+          %{"$ref" => make_class_ref(family, item[:name])}
+        end)
 
       Map.put(schema, "oneOf", refs)
     else

--- a/server/lib/schema/translator.ex
+++ b/server/lib/schema/translator.ex
@@ -24,7 +24,14 @@ defmodule Schema.Translator do
         :skill ->
           case Map.get(data, "id") do
             nil ->
-              data
+              case Map.get(data, "name") do
+                nil ->
+                  data
+
+                name ->
+                  Logger.debug("translate skill class: #{name}")
+                  Schema.skill(Schema.Utils.descope(name))
+              end
 
             class_uid ->
               Logger.debug("translate skill class: #{class_uid}")
@@ -34,7 +41,14 @@ defmodule Schema.Translator do
         :domain ->
           case Map.get(data, "id") do
             nil ->
-              data
+              case Map.get(data, "name") do
+                nil ->
+                  data
+
+                name ->
+                  Logger.debug("translate domain class: #{name}")
+                  Schema.domain(Schema.Utils.descope(name))
+              end
 
             class_uid ->
               Logger.debug("translate domain class: #{class_uid}")
@@ -47,13 +61,8 @@ defmodule Schema.Translator do
               data
 
             name ->
-              if Schema.Types.is_oasf_class?(name) do
-                Logger.debug("translate feature class: #{name}")
-                Schema.feature(Schema.Utils.descope(name))
-              else
-                Logger.debug("not an OASF extension: #{name}")
-                data
-              end
+              Logger.debug("translate feature class: #{name}")
+              Schema.feature(Schema.Utils.descope(name))
           end
 
         :object ->

--- a/server/lib/schema/types.ex
+++ b/server/lib/schema/types.ex
@@ -45,10 +45,26 @@ defmodule Schema.Types do
   end
 
   @doc """
-  Makes longer class name from class type/family, category and name.
+  Makes class name as its unique identifier within OASF by adding classes it extends from,
+  excluding base classes.
   """
-  def long_class_name(family, name) do
-    "#{@schema_uri}/#{family}s/#{name}"
+  def class_name_with_hierarchy(name, all_classes) do
+    base_items = ["base_class", "base_skill", "base_domain", "base_feature"]
+    hierarchy = build_hierarchy(name, all_classes, [])
+    filtered = Enum.reject(hierarchy, &(&1 in base_items))
+    Enum.join(filtered ++ [name], "/")
+  end
+
+  defp build_hierarchy(name, class_map, acc) do
+    key = if is_atom(name), do: name, else: String.to_atom(name)
+
+    case Map.get(class_map, key) do
+      %{extends: parent} when parent not in [nil, ""] ->
+        build_hierarchy(parent, class_map, [parent | acc])
+
+      _ ->
+        acc
+    end
   end
 
   def is_oasf_class?(name) do

--- a/server/lib/schema/types.ex
+++ b/server/lib/schema/types.ex
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Schema.Types do
-  @schema_uri "schema.oasf.agntcy.org"
-
   @moduledoc """
   Schema types and helpers functions to make unique identifiers.
   """
@@ -65,9 +63,5 @@ defmodule Schema.Types do
       _ ->
         acc
     end
-  end
-
-  def is_oasf_class?(name) do
-    String.starts_with?(name, @schema_uri)
   end
 end

--- a/server/lib/schema/validator.ex
+++ b/server/lib/schema/validator.ex
@@ -142,19 +142,7 @@ defmodule Schema.Validator do
           validate_class_id_or_name(response, input, &Schema.find_domain/1, &Schema.domain/1)
 
         :feature ->
-          if Schema.Types.is_oasf_class?(input["name"]) do
-            validate_class_id_or_name(response, input, nil, &Schema.feature/1)
-          else
-            response =
-              add_warning(
-                response,
-                "feature_unknown",
-                "Feature \"#{input["name"]}\" is not an OASF extension; skipping validation.",
-                %{attribute_path: "name", attribute: "name", value: input["name"]}
-              )
-
-            {response, nil}
-          end
+          validate_class_id_or_name(response, input, nil, &Schema.feature/1)
 
         :object ->
           validate_object_name_and_return_object(response, options)
@@ -1443,19 +1431,7 @@ defmodule Schema.Validator do
               validate_class_id_or_name(response, value, &Schema.find_domain/1, &Schema.domain/1)
 
             "feature" ->
-              if Schema.Types.is_oasf_class?(value["name"]) do
-                validate_class_id_or_name(response, value, nil, &Schema.feature/1)
-              else
-                response =
-                  add_warning(
-                    response,
-                    "feature_unknown",
-                    "Feature \"#{value["name"]}\" is not an OASF extension; skipping validation.",
-                    %{attribute_path: "name", attribute: "name", value: value["name"]}
-                  )
-
-                {response, nil}
-              end
+              validate_class_id_or_name(response, value, nil, &Schema.feature/1)
 
             _ ->
               # This should never happen for published schemas (validator will catch this) but

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -364,7 +364,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 10101,
-            name: "schema.oasf.agntcy.org/skills/contextual_comprehension"
+            name: "natural_language_processing/natural_language_understanding/contextual_comprehension"
           })
         end,
       Domain:
@@ -384,7 +384,7 @@ defmodule SchemaWeb.SchemaController do
 
           example(%{
             id: 101,
-            name: "schema.oasf.agntcy.org/domains/technology"
+            name: "technology/internet_of_things"
           })
         end,
       Feature:
@@ -419,7 +419,7 @@ defmodule SchemaWeb.SchemaController do
               },
               export_format: "csv"
             },
-            name: "schema.oasf.agntcy.org/features/observability",
+            name: "observability",
             version: "v0.2.2"
           })
         end,
@@ -500,11 +500,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 10101,
-                name: "schema.oasf.agntcy.org/skills/contextual_comprehension"
+                name: "natural_language_processing/natural_language_understanding/contextual_comprehension"
               },
               %{
                 id: 10203,
-                name: "schema.oasf.agntcy.org/skills/paraphrasing"
+                name: "natural_language_processing/natural_language_generation/paraphrasing"
               }
             ]
           })
@@ -565,11 +565,11 @@ defmodule SchemaWeb.SchemaController do
             inputs: [
               %{
                 id: 101,
-                name: "schema.oasf.agntcy.org/domains/internet_of_things"
+                name: "technology/internet_of_things	"
               },
               %{
                 id: 403,
-                name: "schema.oasf.agntcy.org/domains/fraud_prevention"
+                name: "trust_and_safety_domain/fraud_prevention"
               }
             ]
           })
@@ -640,7 +640,7 @@ defmodule SchemaWeb.SchemaController do
                   },
                   export_format: "csv"
                 },
-                name: "schema.oasf.agntcy.org/features/observability",
+                name: "observability",
                 version: "v0.2.2"
               }
             ]

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -625,6 +625,10 @@ defmodule SchemaWeb.PageView do
     end
   end
 
+  defp break_on_slash(str) do
+    String.replace(str, "/", "/<wbr>")
+  end
+
   defp enum_description(conn, description, attribute_key, attribute) do
     enum_values_table =
       if Map.has_key?(attribute, :enum) do
@@ -654,12 +658,12 @@ defmodule SchemaWeb.PageView do
               [
                 "<tr class=\"",
                 css_classes,
-                "\"><td style=\"width: 25px\" class=\"text-right\" id=\"",
+                "\"><td class=\"text-right\" id=\"",
                 to_string(attribute_key),
                 "-",
                 id,
                 "\"><code>",
-                id,
+                break_on_slash(id),
                 "</code></td><td class=\"textnowrap\">",
                 Map.get(item, :caption, id),
                 "<div class=\"text-secondary\">",

--- a/server/priv/static/css/tables.css
+++ b/server/priv/static/css/tables.css
@@ -6,7 +6,6 @@ table {
   overflow: hidden;
   box-shadow: var(--shadow-sm);
   margin-bottom: var(--spacing-sm);
-  width: 100%;
   table-layout: fixed;
   word-wrap: break-word;
 }
@@ -164,6 +163,7 @@ tr.thead-color th a:hover {
 }
 
 table.table-borderless {
+  table-layout: auto;
   border: none;
   box-shadow: none;
 }
@@ -185,9 +185,9 @@ table.table-borderless th {
 }
 
 /* Enum number column - ensure adequate width */
-.table-borderless tbody td[style*="width: 25px"] {
-  width: 5rem !important;
-  min-width: 5rem;
+.table-borderless tbody td:first-child {
+	min-width: 5rem;
+  white-space: nowrap;
   padding-right: 1rem;
   text-align: right;
 }


### PR DESCRIPTION
Instead of URIs, use class names unique within the current OASF session containing the class hierarchy, so instead of `schema.oasf.agntcy.org/skills/contextual_comprehension` it will be `natural_language_processing/natural_language_understanding/contextual_comprehension`.

Also exceptions were removed from feature validation so from now on only features that exist in the OASF instance are accepted.

Closes #224 