### PR TITLE
feat(server, schema): add unit_interval_t with generator

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -464,7 +464,7 @@
     "priority": {
       "caption": "Priority",
       "description": "Value that indicates a priority of an entity. See specific usage.",
-      "type": "float_t"
+      "type": "unit_interval_t"
     },
     "protocol": {
       "caption": "ACP Endpoint",
@@ -762,6 +762,13 @@
         "description": "The timestamp format is the number of milliseconds since the Epoch 01/01/1970 00:00:00 UTC. For example:<br><code>1618524549901</code>.",
         "type": "long_t",
         "type_name": "Long"
+      },
+      "unit_interval_t": {
+        "caption": "Unit Interval",
+        "description": "Unit interval is defined as the closed interval, which includes all real numbers greater than or equal to 0 and less than or equal to 1.",
+        "type": "float_t",
+        "type_name": "Float",
+        "range": [0, 1]
       },
       "uri_t": {
         "caption": "URI String",

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -536,6 +536,7 @@ defmodule Schema.Generator do
 
   defp generate_data(_name, "file_hash_t", _field), do: sha256()
   defp generate_data(_name, "url_t", _field), do: url()
+  defp generate_data(_name, "unit_interval_t", _field), do: unit_interval()
   defp generate_data(_name, "uuid_t", _field), do: uuid()
   defp generate_data(_name, "ip_t", _field), do: ipv4()
   defp generate_data(_name, "subnet_t", _field), do: subnet()
@@ -696,6 +697,12 @@ defmodule Schema.Generator do
 
   def uuid() do
     UUID.uuid1()
+  end
+
+  def unit_interval() do
+    max_representable_int = :math.pow(2, 53) |> trunc
+    random_integer = random(max_representable_int + 1)
+    random_integer / max_representable_int
   end
 
   def timezone() do


### PR DESCRIPTION
Created new type which is a float between (and included) 0 and 1 to be used for the `priority` attribute with generator. Validation is also take care of due to the `range` constraints of the type.

Fixes #237 