### PR TITLE
fix(server): class indentation of classes from extensions

### DIFF
--- a/server/lib/schema_web/templates/page/index.html.eex
+++ b/server/lib/schema_web/templates/page/index.html.eex
@@ -32,7 +32,7 @@ SPDX-License-Identifier: Apache-2.0
     <%= for {class_key, class} <- category[:classes] do %>
     <% class_key_str = Atom.to_string(class_key) %>
     <% class_path = Routes.static_path(@conn, "/" <> @data[:classes_path] <> "/" <> class_key_str) %>
-    <div class="<%= show_deprecated_css_classes(class, "oasf-class") %> <%= indent_class(class[:uid]) %>" <%= raw format_profiles(class[:profiles])%>>
+    <div class="<%= show_deprecated_css_classes(class, "oasf-class") %> <%= indent_class(class) %>" <%= raw format_profiles(class[:profiles])%>>
       <%= raw format_linked_class_caption(class_path, class_key_str, class) %>
     </div>
     <% end %>

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -162,10 +162,17 @@ defmodule SchemaWeb.PageView do
     ["data-profiles='", Enum.join(profiles, ","), "'"]
   end
 
-  def indent_class(uid) do
-    digits = Integer.to_string(uid) |> String.length()
+  def indent_class(class) do
+    digits = Integer.to_string(class[:uid]) |> String.length()
+
     # Calculate level based on uid length
-    level = div(digits - 3, 2)
+    level =
+      if class[:extension_id] != nil do
+        div(digits - 3, 2) - 1
+      else
+        div(digits - 3, 2)
+      end
+
     "indent-level-#{level}"
   end
 


### PR DESCRIPTION
The uid for classes from extensions are calculated in a way that the extension uid prefixes the rest of the uid so it becomes longer. As the indentation level on the UI is based on the length of the uid, this needed to be adjusted.