### PR TITLE
feat(server): add range to json schema generator

### DIFF
--- a/server/lib/schema.ex
+++ b/server/lib/schema.ex
@@ -181,31 +181,6 @@ defmodule Schema do
   @spec data_types :: map()
   def data_types(), do: Repo.data_types()
 
-  @spec data_type?(binary(), binary() | list(binary())) :: boolean()
-  def data_type?(type, type), do: true
-
-  def data_type?(type, base_type) when is_binary(base_type) do
-    types = Map.get(Repo.data_types(), :attributes)
-
-    case Map.get(types, String.to_atom(type)) do
-      nil -> false
-      data -> data[:type] == base_type
-    end
-  end
-
-  def data_type?(type, base_types) do
-    types = Map.get(Repo.data_types(), :attributes)
-
-    case Map.get(types, String.to_atom(type)) do
-      nil ->
-        false
-
-      data ->
-        t = data[:type] || type
-        Enum.any?(base_types, fn b -> b == t end)
-    end
-  end
-
   @spec all_objects() :: map()
   def all_objects(), do: Repo.all_objects()
 


### PR DESCRIPTION
There are `minimum`, `maximum` constraints in the json draft-07 schema, so this PR translates `range` from OASF types to these constraints in the generated schema.

Example schema for the `mcp_server_resource` object:

```json
{
  "$defs": {},
  "$id": "https://schema.oasf.outshift.com/schema/objects/mcp_server_resource",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "additionalProperties": false,
  "oneOf": [
    {
      "not": {
        "required": ["uri"]
      },
      "required": ["uri_template"]
    },
    {
      "not": {
        "required": ["uri_template"]
      },
      "required": ["uri"]
    }
  ],
  "properties": {
    "audience": {
      "items": {
        "enum": ["user", "assistant"],
        "type": "string"
      },
      "title": "Audience",
      "type": "array"
    },
    "description": {
      "title": "Description",
      "type": "string"
    },
    "mime_type": {
      "title": "MIME Type",
      "type": "string"
    },
    "name": {
      "title": "Name",
      "type": "string"
    },
    "priority": {
      "maximum": 1,
      "minimum": 0,
      "title": "Priority",
      "type": "number"
    },
    "title": {
      "title": "Title",
      "type": "string"
    },
    "uri": {
      "title": "URI",
      "type": "string"
    },
    "uri_template": {
      "title": "URI Template",
      "type": "string"
    }
  },
  "required": ["audience", "name"],
  "title": "MCP Server Resource",
  "type": "object"
}
```

Closes #252 