### PR TITLE
feat(server): validate enum objects

### DIFF
--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -468,31 +468,6 @@ defmodule Schema.Cache do
       |> Map.put(:attributes, attributes)
       |> (fn map -> if is_enum, do: Map.put(map, :is_enum, true), else: map end).()
 
-    enriched_children =
-      if is_enum do
-        Enum.into(type[:_children] || %{}, %{}, fn {key, child} ->
-          {enriched_child, ref_entities} =
-            enrich_ex(
-              child,
-              dictionary_attributes,
-              objects,
-              skills,
-              domains,
-              features,
-              Map.new(),
-              child[:is_enum] || false
-            )
-
-          enriched_child = Map.put(enriched_child, :entities, Map.to_list(ref_entities))
-
-          {key, enriched_child}
-        end)
-      else
-        type[:_children] || %{}
-      end
-
-    enriched_type = Map.put(enriched_type, :_children, enriched_children)
-
     {enriched_type, ref_entities}
   end
 

--- a/server/lib/schema/json_schema.ex
+++ b/server/lib/schema/json_schema.ex
@@ -183,12 +183,19 @@ defmodule Schema.JsonSchema do
       Enum.reduce(entities, {%{}, %{}, %{}, %{}}, fn {name, entity},
                                                      {skills, domains, features, objects} ->
         if entity[:is_enum] do
-          Enum.reduce(entity[:_children], {skills, domains, features, objects}, fn {child_name,
-                                                                                    item},
+          Enum.reduce(entity[:_children], {skills, domains, features, objects}, fn child_name,
                                                                                    {skills,
                                                                                     domains,
                                                                                     features,
                                                                                     objects} ->
+            item =
+              case entity[:family] do
+                "skill" -> Schema.entity_ex(:skill, child_name)
+                "domain" -> Schema.entity_ex(:domain, child_name)
+                "feature" -> Schema.entity_ex(:feature, child_name)
+                _ -> Schema.entity_ex(:object, child_name)
+              end
+
             key = String.replace(child_name, "/", "_")
             value = encode_entity(item, false)
 
@@ -316,8 +323,6 @@ defmodule Schema.JsonSchema do
   end
 
   defp encode_type(type) do
-    IO.inspect(type, label: "Encoding type")
-
     case type do
       "string_t" -> "string"
       "integer_t" -> "integer"

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -108,22 +108,9 @@ defmodule Schema.Utils do
     Enum.into(classes, %{}, fn {name, class} ->
       children =
         find_children(all_classes, Atom.to_string(name))
-        |> Enum.map(fn child ->
-          case Map.get(classes, String.to_atom(child[:name])) do
-            nil ->
-              nil
-
-            child_class ->
-              child_class
-              |> Map.put(:class_name, child_class[:caption])
-              |> Map.put(:type, Atom.to_string(:class_t))
-              |> Map.put(:class_type, child_class[:name])
-          end
-        end)
-        |> Enum.reject(&is_nil/1)
-        |> Enum.into(%{}, fn child ->
-          {child.name, child}
-        end)
+        |> Enum.reject(fn item -> item[:hidden?] == true end)
+        |> Enum.map(& &1[:name])
+        |> Enum.map(&to_string/1)
 
       class
       |> Map.put(:_children, children)
@@ -138,22 +125,9 @@ defmodule Schema.Utils do
 
       children =
         find_children(all_objects, Atom.to_string(name))
-        |> Enum.map(fn child ->
-          case Map.get(objects, String.to_atom(child[:name])) do
-            nil ->
-              nil
-
-            child_class ->
-              child_class
-              |> Map.put(:object_name, child_class[:caption])
-              |> Map.put(:type, Atom.to_string(:object_t))
-              |> Map.put(:object_type, child_class[:name])
-          end
-        end)
-        |> Enum.reject(&is_nil/1)
-        |> Enum.into(%{}, fn child ->
-          {child.name, child}
-        end)
+        |> Enum.reject(fn item -> item[:hidden?] == true end)
+        |> Enum.map(& &1[:name])
+        |> Enum.map(&to_string/1)
 
       object
       |> Map.put(:_links, links)

--- a/server/lib/schema/validator.ex
+++ b/server/lib/schema/validator.ex
@@ -437,7 +437,8 @@ defmodule Schema.Validator do
       class,
       profiles,
       options,
-      dictionary
+      dictionary,
+      class[:is_enum] || false
     )
     |> validate_version(input)
     |> validate_constraints(input, class)
@@ -687,7 +688,8 @@ defmodule Schema.Validator do
           map(),
           list(String.t()),
           list(),
-          map()
+          map(),
+          boolean()
         ) :: map()
   defp validate_attributes(
          response,
@@ -696,7 +698,8 @@ defmodule Schema.Validator do
          schema_item,
          profiles,
          options,
-         dictionary
+         dictionary,
+         is_enum
        ) do
     just_one_keys = schema_item[:constraints][:just_one] |> List.wrap()
     present_keys = Enum.filter(just_one_keys, &Map.has_key?(input_item, &1))
@@ -717,7 +720,78 @@ defmodule Schema.Validator do
         schema_item
       end
 
-    schema_attributes = filter_with_profiles(schema_item[:attributes], profiles)
+    {response, schema_attributes} =
+      if is_enum do
+        matching_child =
+          schema_item[:_children]
+          |> Enum.map(&Schema.entity_ex(:object, &1))
+          |> Enum.find(fn child ->
+            child_attrs = child[:attributes] || %{}
+
+            required_keys =
+              child_attrs
+              |> Enum.filter(fn {_k, v} -> v[:requirement] == "required" end)
+              |> Enum.map(fn {k, _v} -> Atom.to_string(k) end)
+
+            # Are all required keys present in input_item?
+            required_present? = Enum.all?(required_keys, &Map.has_key?(input_item, &1))
+            child_attrs_map = Map.new(child_attrs)
+
+            child_attr_keys =
+              child_attrs_map |> Map.keys() |> Enum.map(&Atom.to_string/1) |> MapSet.new()
+
+            input_keys = Map.keys(input_item) |> MapSet.new()
+
+            # Are all keys present in input_item also present in child_attrs?
+            all_keys_present? = MapSet.subset?(input_keys, child_attr_keys)
+
+            # Enum check
+            enums_match? =
+              Enum.all?(child_attrs, fn {attr_name, attr_def} ->
+                if Map.has_key?(attr_def, :enum) and
+                     Map.has_key?(input_item, Atom.to_string(attr_name)) do
+                  input_val = input_item[Atom.to_string(attr_name)]
+
+                  input_val_atom =
+                    if is_atom(input_val),
+                      do: input_val,
+                      else: String.to_atom(to_string(input_val))
+
+                  input_val_str = to_string(input_val)
+
+                  Map.has_key?(attr_def[:enum], input_val_atom) or
+                    Map.has_key?(attr_def[:enum], input_val_str)
+                else
+                  true
+                end
+              end)
+
+            required_present? and all_keys_present? and enums_match?
+          end)
+
+        if matching_child do
+          {response, filter_with_profiles(matching_child[:attributes], profiles)}
+        else
+          attribute_name = schema_item[:name] || "unknown_enum"
+          attribute_path = make_attribute_path(parent_attribute_path, attribute_name)
+
+          {
+            add_error(
+              response,
+              "enum_object_not_matched",
+              "The object provided for attribute \"#{attribute_path}\" does not match any of allowed objects.",
+              %{
+                attribute_path: attribute_path,
+                attribute: attribute_name,
+                allowed_object_names: Enum.join(schema_item[:_children], ", ")
+              }
+            ),
+            []
+          }
+        end
+      else
+        {response, filter_with_profiles(schema_item[:attributes], profiles)}
+      end
 
     response
     |> validate_attributes_types(
@@ -1471,7 +1545,8 @@ defmodule Schema.Validator do
           Schema.object(object_type),
           profiles,
           options,
-          dictionary
+          dictionary,
+          attribute_details[:is_enum] || false
         )
 
       _ ->
@@ -1494,7 +1569,8 @@ defmodule Schema.Validator do
           map(),
           list(String.t()),
           list(),
-          map()
+          map(),
+          boolean()
         ) :: map()
   defp validate_map_against_object(
          response,
@@ -1504,7 +1580,8 @@ defmodule Schema.Validator do
          schema_object,
          profiles,
          options,
-         dictionary
+         dictionary,
+         is_enum
        ) do
     response
     |> validate_object_deprecated(attribute_path, attribute_name, schema_object)
@@ -1514,7 +1591,8 @@ defmodule Schema.Validator do
       schema_object,
       profiles,
       options,
-      dictionary
+      dictionary,
+      is_enum
     )
     |> validate_constraints(input_object, schema_object, attribute_path)
   end


### PR DESCRIPTION
If an attribute is an enum object, now the validator tries to find the matching children for the input, if there are no matches, it returns an error.

Fixes #240 