### PR TITLE
fix(schema, server): schema types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,8 @@ body:
         - v0.3.1
         - v0.4.0
         - v0.5.0
-        - v0.6.0-dev
+        - v0.6.0
+        - v0.7.0-dev
       default: 2 # v0.5.0
     validations:
       required: false

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -533,7 +533,7 @@
     "mime_type": {
       "caption": "MIME Type",
       "description": "The MIME type of the content. For example: <code>application/json</code>, <code>text/plain</code>.",
-      "type": "mime_type"
+      "type": "mime_t"
     },
     "model": {
       "caption": "Model",
@@ -834,7 +834,7 @@
         "type": "string_t",
         "type_name": "String"
       },
-      "mime_type": {
+      "mime_t": {
         "caption": "MIME Type",
         "description": "MIME type of the content. For example:<br><code>application/json</code>,<br><code>text/plain</code>.",
         "regex": "^([a-zA-Z0-9!#$%&'*+\\-.^_`|~]+/)?[a-zA-Z0-9!#$%&'*+\\-.^_`|~]+$",

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -460,7 +460,6 @@ defmodule Schema.Generator do
   defp generate_data(:owner, _type, _field), do: full_name(2)
   defp generate_data(:labels, _type, _field), do: word()
   defp generate_data(:facility, _type, _field), do: facility()
-  defp generate_data(:mime_type, _type, _field), do: path_name(2)
 
   defp generate_data(key, "string_t", field) do
     name = Atom.to_string(key)
@@ -516,6 +515,7 @@ defmodule Schema.Generator do
   defp generate_data(_name, "float_t", _field), do: random_float(100, 100)
   defp generate_data(_name, "file_name_t", _field), do: file_name(0)
   defp generate_data(_name, "path_t", _field), do: root_dir(5)
+  defp generate_data(_name, "mime_t", _field), do: path_name(2)
 
   defp generate_data(:type, _type, _field), do: word()
   defp generate_data(:name, _type, _field), do: String.capitalize(word())

--- a/server/lib/schema_web/router.ex
+++ b/server/lib/schema_web/router.ex
@@ -69,8 +69,6 @@ defmodule SchemaWeb.Router do
     get "/object/graph/:extension/:id", PageController, :object_graph
 
     get "/data_types", PageController, :data_types
-
-    get "/agent_model", PageController, :agent_model
   end
 
   # Other scopes may use custom stacks.

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -481,6 +481,10 @@ defmodule SchemaWeb.PageView do
     format_integer_constraints(field)
   end
 
+  def format_constraints("float_t", field) do
+    format_integer_constraints(field)
+  end
+
   def format_constraints("long_t", field) do
     format_integer_constraints(field)
   end


### PR DESCRIPTION
Small fixes regarding the `mime_t` and `unit_interval_t` types, also some minor chores.

Fixes #271 