### PR TITLE
feat(server): improve children object/class display

### DIFF
--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -123,25 +123,22 @@ defmodule Schema.Cache do
     # Missing description warnings, datetime attributes, and profiles
     objects =
       objects
-      |> Utils.update_objects(all_objects, dictionary_attributes)
+      |> Utils.update_objects(dictionary_attributes)
       |> update_objects()
       |> final_check(dictionary_attributes)
 
     skills =
       skills
-      |> Utils.update_classes(all_skills)
       |> update_classes(objects)
       |> final_check(dictionary_attributes)
 
     domains =
       domains
-      |> Utils.update_classes(all_domains)
       |> update_classes(objects)
       |> final_check(dictionary_attributes)
 
     features =
       features
-      |> Utils.update_classes(all_features)
       |> update_classes(objects)
       |> final_check(dictionary_attributes)
 

--- a/server/lib/schema/json_schema.ex
+++ b/server/lib/schema/json_schema.ex
@@ -183,13 +183,27 @@ defmodule Schema.JsonSchema do
       Enum.reduce(entities, {%{}, %{}, %{}, %{}}, fn {name, entity},
                                                      {skills, domains, features, objects} ->
         if entity[:is_enum] do
-          Enum.reduce(entity[:_children], {skills, domains, features, objects}, fn child_name,
-                                                                                   {skills,
-                                                                                    domains,
-                                                                                    features,
-                                                                                    objects} ->
+          family = entity[:family]
+
+          all_entities =
+            case family do
+              "skill" -> Schema.all_skills()
+              "domain" -> Schema.all_domains()
+              "feature" -> Schema.all_features()
+              _ -> Schema.all_objects()
+            end
+
+          children =
+            Utils.find_children(all_entities, Atom.to_string(name))
+            |> Enum.reject(fn item -> item[:hidden?] == true end)
+            |> Enum.map(& &1[:name])
+            |> Enum.map(&to_string/1)
+
+          Enum.reduce(children, {skills, domains, features, objects}, fn child_name,
+                                                                         {skills, domains,
+                                                                          features, objects} ->
             item =
-              case entity[:family] do
+              case family do
                 "skill" -> Schema.entity_ex(:skill, child_name)
                 "domain" -> Schema.entity_ex(:domain, child_name)
                 "feature" -> Schema.entity_ex(:feature, child_name)

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -103,35 +103,13 @@ defmodule Schema.Utils do
     |> define_datetime_attributes()
   end
 
-  @spec update_classes(map(), map()) :: map()
-  def update_classes(classes, all_classes) do
-    Enum.into(classes, %{}, fn {name, class} ->
-      children =
-        find_children(all_classes, Atom.to_string(name))
-        |> Enum.reject(fn item -> item[:hidden?] == true end)
-        |> Enum.map(& &1[:name])
-        |> Enum.map(&to_string/1)
-
-      class
-      |> Map.put(:_children, children)
-      |> (&{name, &1}).()
-    end)
-  end
-
-  @spec update_objects(map(), map(), map()) :: map()
-  def update_objects(objects, all_objects, dictionary) do
+  @spec update_objects(map(), map()) :: map()
+  def update_objects(objects, dictionary) do
     Enum.into(objects, %{}, fn {name, object} ->
       links = object_links(dictionary, Atom.to_string(name))
 
-      children =
-        find_children(all_objects, Atom.to_string(name))
-        |> Enum.reject(fn item -> item[:hidden?] == true end)
-        |> Enum.map(& &1[:name])
-        |> Enum.map(&to_string/1)
-
       object
       |> Map.put(:_links, links)
-      |> Map.put(:_children, children)
       |> (&{name, &1}).()
     end)
   end

--- a/server/lib/schema/validator.ex
+++ b/server/lib/schema/validator.ex
@@ -722,8 +722,16 @@ defmodule Schema.Validator do
 
     {response, schema_attributes} =
       if is_enum do
+        name = schema_item[:name]
+
+        children =
+          Schema.Utils.find_children(Schema.all_objects(), name)
+          |> Enum.reject(fn item -> item[:hidden?] == true end)
+          |> Enum.map(& &1[:name])
+          |> Enum.map(&to_string/1)
+
         matching_child =
-          schema_item[:_children]
+          children
           |> Enum.map(&Schema.entity_ex(:object, &1))
           |> Enum.find(fn child ->
             child_attrs = child[:attributes] || %{}
@@ -783,7 +791,7 @@ defmodule Schema.Validator do
               %{
                 attribute_path: attribute_path,
                 attribute: attribute_name,
-                allowed_object_names: Enum.join(schema_item[:_children], ", ")
+                allowed_object_names: Enum.join(children, ", ")
               }
             ),
             []

--- a/server/lib/schema_web/controllers/page_controller.ex
+++ b/server/lib/schema_web/controllers/page_controller.ex
@@ -283,10 +283,15 @@ defmodule SchemaWeb.PageController do
         send_resp(conn, 404, "Not Found: #{id}")
 
       data ->
+        children =
+          Schema.Utils.find_children(Schema.all_skills(), data[:name])
+          |> Enum.reject(fn item -> item[:hidden?] == true end)
+
         data =
           data
           |> sort_attributes_by_key()
           |> Map.put(:key, Schema.Utils.to_uid(extension, id))
+          |> Map.put(:_children, children)
 
         render(conn, "class.html",
           extensions: Schema.extensions(),
@@ -325,10 +330,15 @@ defmodule SchemaWeb.PageController do
         send_resp(conn, 404, "Not Found: #{id}")
 
       data ->
+        children =
+          Schema.Utils.find_children(Schema.all_domains(), data[:name])
+          |> Enum.reject(fn item -> item[:hidden?] == true end)
+
         data =
           data
           |> sort_attributes_by_key()
           |> Map.put(:key, Schema.Utils.to_uid(extension, id))
+          |> Map.put(:_children, children)
 
         render(conn, "class.html",
           extensions: Schema.extensions(),
@@ -367,10 +377,15 @@ defmodule SchemaWeb.PageController do
         send_resp(conn, 404, "Not Found: #{id}")
 
       data ->
+        children =
+          Schema.Utils.find_children(Schema.all_features(), data[:name])
+          |> Enum.reject(fn item -> item[:hidden?] == true end)
+
         data =
           data
           |> sort_attributes_by_key()
           |> Map.put(:key, Schema.Utils.to_uid(extension, id))
+          |> Map.put(:_children, children)
 
         render(conn, "class.html",
           extensions: Schema.extensions(),

--- a/server/lib/schema_web/controllers/page_controller.ex
+++ b/server/lib/schema_web/controllers/page_controller.ex
@@ -407,10 +407,15 @@ defmodule SchemaWeb.PageController do
         send_resp(conn, 404, "Not Found: #{id}")
 
       data ->
+        children =
+          Schema.Utils.find_children(Schema.all_objects(), data[:name])
+          |> Enum.reject(fn item -> item[:hidden?] == true end)
+
         data =
           data
           |> sort_attributes_by_key()
           |> Map.put(:key, Schema.Utils.to_uid(params["extension"], id))
+          |> Map.put(:_children, children)
 
         render(conn, "object.html",
           extensions: Schema.extensions(),

--- a/server/lib/schema_web/controllers/schema_controller.ex
+++ b/server/lib/schema_web/controllers/schema_controller.ex
@@ -1474,7 +1474,7 @@ defmodule SchemaWeb.SchemaController do
   def objects(conn, params) do
     objects =
       Enum.map(objects(params), fn {_name, map} ->
-        Map.delete(map, :_links) |> Map.delete(:_children) |> Schema.delete_attributes()
+        Map.delete(map, :_links) |> Schema.delete_attributes()
       end)
 
     send_json_resp(conn, objects)

--- a/server/lib/schema_web/templates/page/class.html.eex
+++ b/server/lib/schema_web/templates/page/class.html.eex
@@ -8,25 +8,23 @@ SPDX-License-Identifier: Apache-2.0
 <% extension = @data[:extension] %>
 <% references = @data[:references] %>
 <% constraints = @data[:constraints] %>
+<%
+class_type = @data[:family]
+
+path = case class_type do
+  "skill" ->
+    Routes.static_path(@conn, "/main_skills/" <> category)
+  "feature" ->
+    Routes.static_path(@conn, "/main_features/" <> category)
+  "domain" ->
+    Routes.static_path(@conn, "/main_domains/" <> category)
+  _ ->
+    ""
+end
+%>
 
 <div class="row">
   <div class="col-md move-up">
-    <%
-    class_type = @data[:family]
-
-    path = case class_type do
-      "class" ->
-        Routes.static_path(@conn, "/categories/" <> category)
-      "skill" ->
-        Routes.static_path(@conn, "/main_skills/" <> category)
-      "feature" ->
-        Routes.static_path(@conn, "/main_features/" <> category)
-      "domain" ->
-        Routes.static_path(@conn, "/main_domains/" <> category)
-      _ ->
-        ""
-    end
-    %>
     <h3 class="extensions">
       <%= @data[:caption] %>
       <span class="text-secondary">[<a href="<%= class_graph_path(@conn, @data)  %>"><%= @data[:uid] %></a>]<%= if extension && extension != "" do %><span class="extension-badge"><%= extension %></span><% end %>
@@ -140,6 +138,18 @@ SPDX-License-Identifier: Apache-2.0
   <h5 class="mt-3">Attribute Associations</h5>
   <div class="text-monospace">
     <%= raw associations(associations) %>
+  </div>
+<% end %>
+
+<% children = @data[:_children] %>
+<%= if Enum.empty?(children) do %>
+  <div></div>
+<% else %>
+  <div class="referenced-by-section">
+    <a class="referenced-by-toggle" data-toggle="collapse" data-target="#entity-children" aria-expanded="false" aria-controls="entity-children">Children</a>
+    <div class="referenced-by-content extensions collapse" id="entity-children">
+      <%= raw entity_children(@conn, children, class_type) %>
+    </div>
   </div>
 <% end %>
 

--- a/server/lib/schema_web/templates/page/object.html.eex
+++ b/server/lib/schema_web/templates/page/object.html.eex
@@ -102,32 +102,16 @@ SPDX-License-Identifier: Apache-2.0
 </div>
 <% end %>
 
-<%= if Enum.empty?(@data[:_children]) do %>
-<div></div>
+<% children = @data[:_children] %>
+<%= if Enum.empty?(children) do %>
+  <div></div>
 <% else %>
-<div class="mt-4">
-  <h5>Children objects</h5>
-  <table id="data-table" class="table table-bordered sortable">
-    <thead>
-      <tr class="thead-color">
-        <th class="col-name">Name</th>
-        <th class="col-caption">Caption</th>
-        <th class="col-type">Type</th>
-        <th class="col-description">Description</th>
-      </tr>
-    </thead>
-    <tbody class="searchable">
-      <%= for {attribute_key, attribute} <- @data[:_children] do %>
-      <tr class="<%= field_classes(attribute)%>">
-        <td class="name" data-toggle="tooltip" title="<%= format_object_attribute_source(@data[:attribute_key], attribute) %>"><%= format_attribute_name(attribute_key) %></td>
-        <td><%= raw format_attribute_caption(@conn, attribute_key, attribute) %></td>
-        <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
-        <td><%= raw format_attribute_desc(@conn, attribute_key, attribute) %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
-</div>
+  <div class="referenced-by-section">
+    <a class="referenced-by-toggle" data-toggle="collapse" data-target="#entity-children" aria-expanded="false" aria-controls="entity-children">Children</a>
+    <div class="referenced-by-content extensions collapse" id="entity-children">
+      <%= raw entity_children(@conn, children, "object") %>
+    </div>
+  </div>
 <% end %>
 
 <% links = @data[:_links] %>
@@ -141,6 +125,7 @@ SPDX-License-Identifier: Apache-2.0
     </div>
   </div>
 <% end %>
+
 <%= if constraints != nil and map_size(constraints) > 0 do %>
   <h5 class="mt-3">Constraints</h5>
   <div>

--- a/server/lib/schema_web/views/page_view.ex
+++ b/server/lib/schema_web/views/page_view.ex
@@ -1116,6 +1116,29 @@ defmodule SchemaWeb.PageView do
     end
   end
 
+  @spec entity_children(any(), list(Schema.Utils.link_t()), String.t()) ::
+          <<>> | list()
+  def entity_children(conn, children, type)
+  def entity_children(_, nil, _), do: ""
+  def entity_children(_, [], _), do: ""
+
+  def entity_children(conn, children, type) do
+    entities_html =
+      [
+        case type do
+          "skill" -> entity_children_to_html(conn, children, "skill")
+          "domain" -> entity_children_to_html(conn, children, "domain")
+          "feature" -> entity_children_to_html(conn, children, "feature")
+          "object" -> entity_children_to_html(conn, children, "object")
+          _ -> []
+        end
+      ]
+      |> Enum.reject(&Enum.empty?/1)
+
+    Enum.reject([entities_html], &Enum.empty?/1)
+    |> Enum.intersperse("<hr>")
+  end
+
   @spec object_links(any(), String.t(), list(Schema.Utils.link_t()), nil | :collapse) ::
           <<>> | list()
   def object_links(conn, name, links, list_presentation \\ nil)
@@ -1299,6 +1322,56 @@ defmodule SchemaWeb.PageView do
           ["Referenced by ", Integer.to_string(length(html_list)), noun_text, deprecated_text],
           html_list
         )
+
+      true ->
+        ["<dl class=\"m-0\">", html_list, "</dl>"]
+    end
+  end
+
+  defp entity_children_to_html(conn, children, type) do
+    html_list =
+      reverse_sort_links(children)
+      |> Enum.reduce(
+        [],
+        fn child, acc ->
+          type_path =
+            case type do
+              "skill" ->
+                SchemaWeb.Router.Helpers.static_path(conn, "/skills/" <> child[:name])
+
+              "domain" ->
+                SchemaWeb.Router.Helpers.static_path(conn, "/domains/" <> child[:name])
+
+              "feature" ->
+                SchemaWeb.Router.Helpers.static_path(conn, "/features/" <> child[:name])
+
+              "object" ->
+                SchemaWeb.Router.Helpers.static_path(conn, "/objects/" <> child[:name])
+
+              _ ->
+                "#"
+            end
+
+          [
+            [
+              "<div class=\"",
+              link_css_classes(child),
+              "\"><dt><a href=\"",
+              type_path,
+              "\">",
+              child[:caption],
+              "</a>",
+              link_deprecated(child),
+              "</div>"
+            ]
+            | acc
+          ]
+        end
+      )
+
+    cond do
+      Enum.empty?(html_list) ->
+        []
 
       true ->
         ["<dl class=\"m-0\">", html_list, "</dl>"]

--- a/server/priv/static/css/components.css
+++ b/server/priv/static/css/components.css
@@ -562,7 +562,7 @@ button:hover,
 /* Multi-column layout for referenced content */
 .referenced-by-content {
   column-count: auto;
-  column-width: 300px;
+  column-width: auto;
   column-gap: var(--spacing-lg);
   column-fill: balance;
 }


### PR DESCRIPTION
Display children of a viewed class/object similar to how the Referenced by objects are displayed on the UI.

| Before | After |
|:------:|:-----:|
| <img width="1129" height="672" alt="Screenshot 2025-09-02 at 18 00 47" src="https://github.com/user-attachments/assets/ef91f1f6-d143-4071-ad89-36205d578be7" /> | <img width="1129" height="672" alt="Screenshot 2025-09-02 at 18 00 51" src="https://github.com/user-attachments/assets/475cc012-f819-40e8-8022-a116961b8c28" /> |
| <img width="1129" height="672" alt="Screenshot 2025-09-02 at 18 00 42" src="https://github.com/user-attachments/assets/81721a5c-5250-4882-9512-57aee24a06f4" /> | <img width="1129" height="672" alt="Screenshot 2025-09-02 at 18 00 56" src="https://github.com/user-attachments/assets/402b875a-6422-41c1-a4b2-9b06b95fb570" /> |

Fixes #281 