### PR TITLE
feat: add base object to OASF

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,10 @@ vars:
   KUBECTL_BIN: '{{ .BIN_DIR }}/kubectl-{{.KUBECTL_VERSION}}'
   KIND_VERSION: '0.25.0'
   KIND_BIN: '{{ .BIN_DIR }}/kind-{{.KIND_VERSION}}'
+  PROTOC_VERSION: '27.1'
+  PROTOC_BIN: '{{ .BIN_DIR }}/protoc-{{.PROTOC_VERSION}}'
+  BUFBUILD_VERSION: '1.50.1'
+  BUFBUILD_BIN: '{{ .BIN_DIR }}/bufbuild-{{.BUFBUILD_VERSION}}'
 
 ## Set refresh interval for observable tasks like hot-reload
 interval: 500ms
@@ -208,11 +212,24 @@ tasks:
       # TODO: add test cases here
 
   lint:
+    desc: Run all linters
     cmds:
+      - task: lint:proto
       - task: lint:charts
 
+  lint:proto:
+    desc: Run Proto linters
+    deps:
+      - task: deps:protoc
+      - task: deps:bufbuild
+    dir: ./proto
+    cmds:
+      - '{{.BUFBUILD_BIN}} dep update'
+      - '{{.BUFBUILD_BIN}} format --diff --exit-code'
+      - '{{.BUFBUILD_BIN}} lint'
+
   lint:charts:
-    desc: Lint helm charts
+    desc: Run Helm linters
     deps:
       - deps:helm
     vars:
@@ -223,7 +240,23 @@ tasks:
         cmd: 'cd {{ .ITEM }} && {{ .HELM_BIN }} lint'
 
   fmt:
-    desc: Format schema files
+    desc: Run formatters
+    cmds:
+      - task: fmt:proto
+      - task: fmt:schema
+
+  fmt:proto:
+    desc: Run Proto formatters
+    deps:
+      - task: deps:protoc
+      - task: deps:bufbuild
+    dir: ./proto
+    cmds:
+      - '{{.BUFBUILD_BIN}} dep update'
+      - '{{.BUFBUILD_BIN}} format --output ./'
+
+  fmt:schema:
+    desc: Run Schema formatters
     preconditions:
       - which jq
     dir: ./schema
@@ -318,3 +351,47 @@ tasks:
       - cmd: mv {{.BIN_DIR}}/kind {{.KIND_BIN}}
     status:
       - test -x {{.KIND_BIN}}
+
+  deps:protoc:
+    desc: Ensure supported Protoc version and plugins are installed
+    internal: true
+    deps:
+      - deps:bin-dir
+    preconditions:
+      - which go
+      - which curl
+      - which unzip
+    vars:
+      ARCH_TYPE: '{{ if eq ARCH "arm64" }}aarch_64{{ else if eq ARCH "amd64" }}x86_64{{else if eq ARCH "s390x"}}x390_64{{ else }}{{ARCH}}{{ end }}'
+      OS_VARIANT: '{{ if eq OS "darwin" }}osx-universal_binary{{ else if eq OS "windows" }}win64{{else}}linux-{{.ARCH_TYPE}}{{ end }}'
+    cmds:
+      - cmd: echo "Downloading Protoc v{{.PROTOC_VERSION}}..."
+      - cmd: |
+          curl -sL https://github.com/protocolbuffers/protobuf/releases/download/v{{.PROTOC_VERSION}}/protoc-{{.PROTOC_VERSION}}-{{.OS_VARIANT}}.zip -o {{.BIN_DIR}}/tmp.zip
+          unzip -j {{.BIN_DIR}}/tmp.zip "bin/protoc" -d {{.BIN_DIR}}
+          mv {{.BIN_DIR}}/protoc {{.PROTOC_BIN}}
+          rm {{.BIN_DIR}}/tmp.zip
+      - cmd: chmod +x {{.PROTOC_BIN}}
+      - cmd: echo "Downloading go plugins for protoc..."
+      - cmd: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+      - cmd: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+      - cmd: go install github.com/NathanBaulch/protoc-gen-cobra@latest
+    status:
+      - test -x {{.PROTOC_BIN}}
+
+  deps:bufbuild:
+    desc: Ensure supported bufbuild version is installed
+    internal: true
+    deps:
+      - deps:bin-dir
+    preconditions:
+      - which curl
+    vars:
+      ARCH_TYPE: '{{ if eq ARCH "amd64" }}x86_64{{ else }}{{ARCH}}{{ end }}'
+    cmds:
+      - cmd: echo "Downloading BufBuild v{{.BUFBUILD_VERSION}}..."
+      - cmd: |
+          curl -L "https://github.com/bufbuild/buf/releases/download/v{{.BUFBUILD_VERSION}}/buf-{{OS}}-{{.ARCH_TYPE}}" -o {{.BUFBUILD_BIN}}
+      - cmd: chmod +x {{.BUFBUILD_BIN}}
+    status:
+      - test -x {{.BUFBUILD_BIN}}

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -6,6 +6,10 @@ lint:
   disallow_comment_ignores: true
   use:
     - STANDARD
+  ignore_only:
+    PACKAGE_VERSION_SUFFIX:
+      - types/v1alpha0
+
 breaking:
   use:
     - WIRE_JSON

--- a/proto/core/v1/object.proto
+++ b/proto/core/v1/object.proto
@@ -1,0 +1,39 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package types.v1alpha0;
+
+import "google/protobuf/struct.proto";
+
+// A specific OASF object in its raw form.
+// Used for wire transmission and storage of OASF objects.
+//
+// The data is represented as a `google.protobuf.Struct` to allow
+// for flexible and dynamic schemas.
+//
+// Golang example:
+//
+//   import (
+//      "google.golang.org/protobuf/types/known/structpb"
+//
+//      corev1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/core/v1"
+//      typesv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/types/v1alpha1"
+//   )
+//
+//   func main() {
+//       // Create a typed Record
+//       record := typesv1alpha1.Record{}
+//
+//       // Convert the Record to a generic struct
+//       recordStruct, _ := structpb.NewStruct(record)
+//
+//       // Create an Object with the struct
+//       object := &corev1.Object{
+//           data: recordStruct,
+//       }
+//   }
+message Object {
+  google.protobuf.Struct data = 1;
+}

--- a/proto/core/v1/object.proto
+++ b/proto/core/v1/object.proto
@@ -3,7 +3,7 @@
 
 syntax = "proto3";
 
-package types.v1alpha0;
+package core.v1;
 
 import "google/protobuf/struct.proto";
 

--- a/proto/core/v1/object.proto
+++ b/proto/core/v1/object.proto
@@ -12,6 +12,7 @@ import "google/protobuf/struct.proto";
 //
 // The data is represented as a `google.protobuf.Struct` to allow
 // for flexible and dynamic schemas.
+// The actual object data schema is defined by OASF.
 //
 // Golang example:
 //
@@ -22,7 +23,7 @@ import "google/protobuf/struct.proto";
 //      typesv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/types/v1alpha1"
 //   )
 //
-//   func main() {
+//   func producer() {
 //       // Create a typed Record
 //       record := typesv1alpha1.Record{}
 //
@@ -34,6 +35,21 @@ import "google/protobuf/struct.proto";
 //           data: recordStruct,
 //       }
 //   }
+//
+//   func consumer(object *corev1.Object) {
+//     // Check for some object type identifier
+//     if object.Data.Fields["schema_version"].GetStringValue() != "v0.7.0" {
+//         return
+//     }
+//
+//     // Convert generic object to JSON
+//     objectJSON, _ := json.Marshal(object.Data)
+//
+//     // Convert the data to a typed Record
+//     var record typesv1alpha1.Record
+//     json.Unmarshal(objectJSON, &record)
+//   }
+//
 message Object {
   google.protobuf.Struct data = 1;
 }


### PR DESCRIPTION
## Overview

This PR adds a base object to OASF protos. The base object can be used to encode any OASF-defined object (such as record, module, etc) into a protobuf `Object` type. This is useful across the infra layer to explicitly differentiate between data coming from OASF and other places.

Goal: OASF defines objects and reserves types via some properties => upstream users leverage and provide functionality for certain objects

## Usage

- To encode any object from OASF into JSON-based protobuf wire format
- Have explicit type to differentiate between OASF and non-OASF objects across gRPC APIs
- Ability to extract/convert a generic `Object` into any schema defined by OASF

**In OASF-SDK**

`DecodingService.DecodeRecord` to convert raw Object into a typed OASF-defined Record, and later to other types as well (e.g. such as typed modules via new RPC)

**In DIR**

To interoperate with different OASF object types, mainly focusing on Record.