### PR TITLE
Fix: graph view

### DIFF
--- a/server/lib/schema/graph.ex
+++ b/server/lib/schema/graph.ex
@@ -31,12 +31,19 @@ defmodule Schema.Graph do
   defp build_nodes(nodes, class) do
     Map.get(class, :entities)
     |> Enum.reduce(nodes, fn {_name, obj}, acc ->
+      color =
+        if obj[:family] do
+          "#C8F5D0"
+        else
+          "#e3e9fb"
+        end
+
       node = %{
         id: make_id(obj.name, obj[:extension]),
-        label: obj.caption
+        label: obj.caption,
+        color: color
       }
 
-      # Don't add class/object that is already added (present infinite loop)
       if not nodes_member?(nodes, node) do
         [node | acc]
       else

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -655,4 +655,13 @@ defmodule Schema.Utils do
       _ -> false
     end
   end
+
+  def get_collection_by_family(family) do
+    case family do
+      "skill" -> Schema.all_skills()
+      "domain" -> Schema.all_domains()
+      "module" -> Schema.all_modules()
+      _ -> Schema.all_objects()
+    end
+  end
 end

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -460,13 +460,18 @@ defmodule Schema.Utils do
     end
   end
 
-  @spec find_children(map(), String.t()) :: [map()]
-  def find_children(map, parent_name) do
+  @spec find_direct_children(map(), String.t()) :: [map()]
+  def find_direct_children(map, parent_name) do
     map
     |> Enum.filter(fn {_key, elem} ->
       Map.has_key?(elem, :extends) && elem[:extends] == parent_name
     end)
     |> Enum.map(fn {_key, elem} -> elem end)
+  end
+
+  @spec find_children(map(), String.t()) :: [map()]
+  def find_children(map, parent_name) do
+    find_direct_children(map, parent_name)
     |> Enum.flat_map(fn elem ->
       [elem | find_children(map, elem[:name])]
     end)

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -655,13 +655,4 @@ defmodule Schema.Utils do
       _ -> false
     end
   end
-
-  def get_collection_by_family(family) do
-    case family do
-      "skill" -> Schema.all_skills()
-      "domain" -> Schema.all_domains()
-      "module" -> Schema.all_modules()
-      _ -> Schema.all_objects()
-    end
-  end
 end

--- a/server/lib/schema_web/templates/page/class_graph.html.eex
+++ b/server/lib/schema_web/templates/page/class_graph.html.eex
@@ -40,7 +40,6 @@ SPDX-License-Identifier: Apache-2.0
      font: {face: 'mono'}
    },
    nodes: {
-     "color": "#e3e9fb",
      shape: 'box',
      font: {face: 'mono'}
    },

--- a/server/lib/schema_web/templates/page/object_graph.html.eex
+++ b/server/lib/schema_web/templates/page/object_graph.html.eex
@@ -34,7 +34,6 @@ SPDX-License-Identifier: Apache-2.0
        font: {face: 'mono'}
      },
      nodes: {
-       "color": "#e3e9fb",
        shape: 'box',
        font: {face: 'mono'}
      },


### PR DESCRIPTION
Graph mode now can handle class type and enum entities so it can render all related entities to an entity.
Closes #118 

## Record object graph

### Before
<img width="629" height="480" alt="Screenshot 2025-09-22 at 10 01 16" src="https://github.com/user-attachments/assets/c905efbf-4509-4316-b1ef-a55739e5bd34" />

### After
<img width="1037" height="849" alt="Screenshot 2025-09-22 at 10 25 34" src="https://github.com/user-attachments/assets/07e9da54-9ab8-4650-b760-7ddfd4e3a85b" />
<img width="1492" height="843" alt="Screenshot 2025-09-22 at 10 26 03" src="https://github.com/user-attachments/assets/ea83ae7e-b157-49aa-a08d-9e20c6afd358" />
