### PR TITLE
feat(schema, server): rearrange Objects page

### DIFF
--- a/proto/agntcy/oasf/types/v1alpha2/domain.proto
+++ b/proto/agntcy/oasf/types/v1alpha2/domain.proto
@@ -1,0 +1,18 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package agntcy.oasf.types.v1alpha2;
+
+// A specific domain under which the record can operate in.
+message Domain {
+  // Unique name of the domain.
+  string name = 1;
+
+  // Unique identifier of the domain.
+  uint32 id = 2;
+
+  // Metadata associated with the domain.
+  map<string, string> annotations = 3;
+}

--- a/proto/agntcy/oasf/types/v1alpha2/locator.proto
+++ b/proto/agntcy/oasf/types/v1alpha2/locator.proto
@@ -1,0 +1,40 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package agntcy.oasf.types.v1alpha2;
+
+// Locator points to the source where record can be found at.
+// For example, a locator can be a link to a helm chart.
+message Locator {
+  // Type of the locator.
+  // Supports custom types.
+  // Native types are defined in the LocatorType.
+  string type = 1;
+
+  // Location where the source can be found at.
+  // Specs: https://datatracker.ietf.org/doc/html/rfc1738
+  string url = 2;
+
+  // Metadata associated with the locator.
+  map<string, string> annotations = 3;
+
+  // Size of the source in bytes pointed by the {url} property.
+  optional uint64 size = 4;
+
+  // Digest of the source pointed by the {url} property.
+  // Specs: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+  optional string digest = 5;
+}
+
+// LocatorType defines placeholders for supported locators.
+// Used in string format across APIs.
+enum LocatorType {
+  LOCATOR_TYPE_UNSPECIFIED = 0; // ""
+  LOCATOR_TYPE_HELM_CHART = 1; // "helm_chart"
+  LOCATOR_TYPE_DOCKER_IMAGE = 2; // "docker_image"
+  LOCATOR_TYPE_PYTHON_PACKAGE = 3; // "python_package"
+  LOCATOR_TYPE_SOURCE_CODE = 4; // "source_code"
+  LOCATOR_TYPE_BINARY = 5; // "binary"
+}

--- a/proto/agntcy/oasf/types/v1alpha2/module.proto
+++ b/proto/agntcy/oasf/types/v1alpha2/module.proto
@@ -1,0 +1,27 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package agntcy.oasf.types.v1alpha2;
+
+import "google/protobuf/struct.proto";
+
+// Modules provide a generic way to attach additional information
+// to the record. For example, application-specific
+// details can be provided using a module.
+message Module {
+  // Name of the module.
+  // Can be used as a fully qualified name.
+  string name = 1;
+
+  // Unique identifier of the module.
+  uint32 id = 2;
+
+  // Metadata associated with the module.
+  map<string, string> annotations = 3;
+
+  // Data attached to the module.
+  // Usually a JSON-embedded object.
+  google.protobuf.Struct data = 4;
+}

--- a/proto/agntcy/oasf/types/v1alpha2/record.proto
+++ b/proto/agntcy/oasf/types/v1alpha2/record.proto
@@ -1,0 +1,66 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package agntcy.oasf.types.v1alpha2;
+
+import "agntcy/oasf/types/v1alpha2/domain.proto";
+import "agntcy/oasf/types/v1alpha2/locator.proto";
+import "agntcy/oasf/types/v1alpha2/module.proto";
+import "agntcy/oasf/types/v1alpha2/skill.proto";
+
+// Record defines a schema for versioned AI agentic content representation.
+// The schema provides a way to describe an agentic record in a structured format.
+//
+// This is a versioned gRPC-based schema of OASF Record object.
+//
+// Max size: 4 MB (or to fully fit in a single request)
+// It may be required to support larger record size in the future.
+//
+// Records are stored in a content-addressable store.
+// Records can be indexed for quick lookups and searches to avoid unnecessary data transfer.
+//
+// All records are referenced by a globally-unique content identifier (CID).
+// Specs: https://github.com/multiformats/cid
+message Record {
+  // Name of the record.
+  string name = 1;
+
+  // Version of the record.
+  string version = 2;
+
+  // Schema version of the record.
+  string schema_version = 3;
+
+  // Description of the record.
+  string description = 4;
+
+  // List of record authors, e.g. in the form of `author-name <author-email>`.
+  repeated string authors = 5;
+
+  // Metadata associated with the record.
+  map<string, string> annotations = 6;
+
+  // Creation timestamp of the record in the RFC3339 format.
+  // Specs: https://www.rfc-editor.org/rfc/rfc3339.html
+  string created_at = 7;
+
+  // List of source locators where the record can be found or used from.
+  repeated Locator locators = 8;
+
+  // List of skills that the record can perform.
+  repeated Skill skills = 9;
+
+  // List of domains under which the record can operate in.
+  repeated Domain domains = 10;
+
+  // Additional information attached to the record.
+  // Modules are used to generically extend the record's functionality.
+  repeated Module modules = 11;
+
+  // Reference to the previous record, if any.
+  // Used to link the record to its previous versions.
+  // Field number is explicitly reserved for extendability.
+  optional string parent_cid = 99;
+}

--- a/proto/agntcy/oasf/types/v1alpha2/signature.proto
+++ b/proto/agntcy/oasf/types/v1alpha2/signature.proto
@@ -1,0 +1,39 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package agntcy.oasf.types.v1alpha2;
+
+// Signature provides the signing and verification details about the record.
+message Signature {
+  // Metadata associated with the signature.
+  map<string, string> annotations = 1;
+
+  // Signing timestamp of the record in the RFC3339 format.
+  // Specs: https://www.rfc-editor.org/rfc/rfc3339.html
+  string signed_at = 2;
+
+  // The signature algorithm used (e.g., "ECDSA_P256_SHA256").
+  string algorithm = 3;
+
+  // Base64-encoded signature.
+  string signature = 4;
+
+  // Base64-encoded signing certificate.
+  string certificate = 5;
+
+  // Type of the signature content bundle.
+  string content_type = 6;
+
+  // Base64-encoded signature bundle produced by the signer.
+  // It is up to the client to interpret the content of the bundle.
+  string content_bundle = 7;
+
+  // Schema version of the record.
+  string schema_version = 8;
+
+  // Used to link the signature to a record.
+  // Field number is explicitly reserved for extendability.
+  optional string parent_cid = 99;
+}

--- a/proto/agntcy/oasf/types/v1alpha2/skill.proto
+++ b/proto/agntcy/oasf/types/v1alpha2/skill.proto
@@ -1,0 +1,18 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package agntcy.oasf.types.v1alpha2;
+
+// A specific skills that a record is capable of performing.
+message Skill {
+  // Unique name of the skill.
+  string name = 1;
+
+  // Unique identifier of the skill.
+  uint32 id = 2;
+
+  // Metadata associated with the skill.
+  map<string, string> annotations = 3;
+}

--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -582,15 +582,15 @@
       "description": "Overall scores of the Agent across all evaluation.",
       "type": "overall_scores"
     },
+    "parent_cid": {
+      "caption": "Parent CID",
+      "description": "The CID of the parent record if this record is a derivative or linked to another record.",
+      "type": "uuid_t"
+    },
     "path": {
       "caption": "Path",
       "description": "The path that pertains to the class or object. See specific usage.",
       "type": "string_t"
-    },
-    "previous_record_cid": {
-      "caption": "Previous Record CID",
-      "description": "Content Identifier (CID) of an Record's parent record.",
-      "type": "uuid_t"
     },
     "priority": {
       "caption": "Priority",
@@ -616,11 +616,6 @@
       "caption": "Quality Score",
       "description": "Overall score.",
       "type": "float_t"
-    },
-    "record_signature": {
-      "caption": "Signature",
-      "description": "A digitital signature is used to verify the authenticity and integrity of the data. See specific usage.",
-      "type": "record_signature"
     },
     "referred_evaluations": {
       "caption": "Referred evaluations",

--- a/schema/objects/linkable.json
+++ b/schema/objects/linkable.json
@@ -1,0 +1,18 @@
+{
+  "caption": "Linkable Object",
+  "description": "Object for direct use and storage with the ability to be linked to other records.",
+  "name": "linkable",
+  "extends": "object",
+  "attributes": {
+    "schema_version": {
+      "caption": "Schema Version",
+      "description": "Version of the OASF schema.",
+      "requirement": "required"
+    },
+    "parent_cid": {
+      "caption": "Parent CID",
+      "description": "The CID of the parent record if this record is a derivative or linked to another record.",
+      "requirement": "optional"
+    }
+  }
+}

--- a/schema/objects/record.json
+++ b/schema/objects/record.json
@@ -1,7 +1,7 @@
 {
   "caption": "Record",
-  "description": "The data model defines a schema for agentic AI data representation. The schema provides a way to describe the workload's modules, constraints, artifact locators, versioning, ownership, or relevant details.",
-  "extends": "object",
+  "description": "The record data model defines a schema for agentic AI data representation. The schema provides a way to describe the workload's modules, constraints, artifact locators, versioning, ownership, or relevant details.",
+  "extends": "linkable",
   "name": "record",
   "attributes": {
     "name": {
@@ -12,11 +12,6 @@
     "version": {
       "caption": "Version",
       "description": "The version of the record. Values MAY conform to a specific versioning schema.",
-      "requirement": "required"
-    },
-    "schema_version": {
-      "caption": "Schema Version",
-      "description": "Version of the OASF schema.",
       "requirement": "required"
     },
     "description": {
@@ -58,17 +53,6 @@
       "caption": "Modules",
       "description": "List of modules that describe this record and its capabilities more in depth.",
       "requirement": "recommended"
-    },
-    "signature": {
-      "reference": "record_signature",
-      "caption": "Signature",
-      "description": "A digital signature of the record data model. This is used to verify the authenticity and integrity of the record.",
-      "requirement": "recommended"
-    },
-    "previous_record_cid": {
-      "caption": "Previous Record CID",
-      "description": "Content Identifier (CID) of the data of the record with the previous version.",
-      "requirement": "optional"
     }
   }
 }

--- a/schema/objects/signature.json
+++ b/schema/objects/signature.json
@@ -1,8 +1,8 @@
 {
   "caption": "Signature",
   "description": "Signature provides the signing and verification details about the record.",
-  "extends": "object",
-  "name": "record_signature",
+  "extends": "linkable",
+  "name": "signature",
   "attributes": {
     "annotations": {
       "caption": "Annotations",

--- a/server/lib/schema_web/controllers/page_controller.ex
+++ b/server/lib/schema_web/controllers/page_controller.ex
@@ -444,7 +444,13 @@ defmodule SchemaWeb.PageController do
   end
 
   def objects(conn, params) do
-    data = SchemaController.objects(params) |> sort_by_descoped_key()
+    data =
+      SchemaController.objects(params)
+      |> sort_by_descoped_key()
+      |> Enum.map(fn
+        {:record, _} -> {:record, SchemaController.object(%{"id" => "record"})}
+        other -> other
+      end)
 
     render(conn, "objects.html",
       extensions: Schema.extensions(),

--- a/server/lib/schema_web/router.ex
+++ b/server/lib/schema_web/router.ex
@@ -19,7 +19,7 @@ defmodule SchemaWeb.Router do
   scope "/", SchemaWeb do
     pipe_through :browser
 
-    get "/", PageController, :main_skills
+    get "/", PageController, :objects
 
     get "/main_skills", PageController, :main_skills
     get "/main_skills/:id", PageController, :main_skills

--- a/server/lib/schema_web/templates/layout/app.html.eex
+++ b/server/lib/schema_web/templates/layout/app.html.eex
@@ -88,9 +88,6 @@
           $('#modules_id a.nav-link').addClass("active");
           $('#classes_id a.nav-link').addClass("active");
           break;
-        case '/objects/record':
-          $('#record_id a.nav-link').addClass("active");
-          break;
         case '/dictionary':
           $('#dictionary_id a.nav-link').addClass("active");
           break;
@@ -214,6 +211,9 @@
 
   <div class="collapse navbar-collapse" id="navbarCollapse">
     <ul class="top-navbar-nav navbar-nav ml-auto">
+      <li id="objects_id"  class="nav-item">
+        <a class="nav-link" href='<%= Routes.static_path(@conn, "/objects") %>'>Objects</a>
+      </li>
       <li id="classes_id" class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" role="button">Classes</a>
         <div class="dropdown-content">
@@ -231,14 +231,8 @@
       <li id="modules_id" class="nav-item">
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/main_modules") %>'>Modules</a>
       </li>
-      <li id="record_id" class="nav-item">
-        <a class="nav-link" href='<%= Routes.static_path(@conn, "/objects/record") %>'>Record</a>
-      </li>
       <li id="dictionary_id" class="nav-item">
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/dictionary") %>'>Dictionary</a>
-      </li>
-      <li id="objects_id"  class="nav-item">
-        <a class="nav-link" href='<%= Routes.static_path(@conn, "/objects") %>'>Objects</a>
       </li>
       <li id="data_types_id" class="nav-item">
         <a class="nav-link" href='<%= Routes.static_path(@conn, "/data_types") %>'>Data Types</a>

--- a/server/lib/schema_web/templates/page/_attribute_table.html.eex
+++ b/server/lib/schema_web/templates/page/_attribute_table.html.eex
@@ -1,0 +1,22 @@
+<table id="data-table" class="table table-bordered sortable">
+  <thead>
+    <tr class="thead-color">
+      <th class="col-name">Name</th>
+      <th class="col-caption">Caption</th>
+      <th class="col-requirement">Requirement</th>
+      <th class="col-type">Type</th>
+      <th class="col-description">Description</th>
+    </tr>
+  </thead>
+  <tbody class="searchable">
+    <%= for {attribute_key, attribute} <- @data[:attributes] do %>
+    <tr class="<%= field_classes(attribute)%>">
+      <td class="name" data-toggle="tooltip" title="<%= format_object_attribute_source(@data[:attribute_key], attribute) %>"><%= format_attribute_name(attribute_key) %></td>
+      <td><%= raw format_attribute_caption(@conn, attribute_key, attribute) %></td>
+      <td><%= raw format_requirement(@data[:constraints], attribute_key, attribute) %></td>
+      <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
+      <td><%= raw format_attribute_desc(@conn, attribute_key, attribute) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/server/lib/schema_web/templates/page/_object_table.html.eex
+++ b/server/lib/schema_web/templates/page/_object_table.html.eex
@@ -1,0 +1,22 @@
+<table class="table table-bordered sortable">
+  <thead>
+    <tr class="thead-color">
+      <th class="col-name">Name</th>
+      <th class="col-caption">Caption</th>
+      <th class="col-references">Referenced By</th>
+      <th class="col-description">Description</th>
+    </tr>
+  </thead>
+  <tbody class="searchable">
+    <%= for {object_key, object} <- @objects do %>
+      <% object_key_str = Atom.to_string(object_key) %>
+      <% object_path = Routes.static_path(@conn, "/objects/" <> object_key_str) %>
+      <tr class=<%= show_deprecated_css_classes(object, "oasf-class") %>" <%= raw format_profiles(object[:profiles])%>>
+        <td class="name"><a href="<%= object_path %>"><%= object_key_str %></a></td>
+        <td class="extensions"><%= raw format_attribute_caption(@conn, object_key_str, object) %></td>
+        <td class="extensions"><%= raw object_links(@conn, object[:name], object[:_links], :collapse) %></td>
+        <td><%= raw description(object) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/server/lib/schema_web/templates/page/class.html.eex
+++ b/server/lib/schema_web/templates/page/class.html.eex
@@ -74,30 +74,7 @@ end
 </div>
 
 <div class="mt-4">
-  <table id="data-table" class="table table-bordered sortable">
-    <thead >
-    <tr class="thead-color">
-      <th class="col-name">Name</th>
-      <th class="col-caption">Caption</th>
-      <th class="col-group">Group</th>
-      <th class="col-requirement">Requirement</th>
-      <th class="col-type">Type</th>
-      <th class="col-description">Description</th>
-    </tr>
-    </thead>
-    <tbody class="searchable">
-      <%= for {attribute_key, attribute} <- @data[:attributes] do %>
-        <tr class="<%= field_classes(attribute) %>">
-          <td class="name" data-toggle="tooltip" title="<%= format_class_attribute_source(@data[:attribute_key], attribute, @data[:family]) %>"><%= format_attribute_name(attribute_key) %></td>
-          <td><%= raw format_attribute_caption(@conn, attribute_key, attribute) %></td>
-          <td class="capitalize"><%= attribute[:group] %></td>
-          <td><%= raw format_requirement(constraints, attribute_key, attribute) %></td>
-          <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
-          <td><%= raw format_attribute_desc(@conn, attribute_key, attribute) %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <%= render SchemaWeb.PageView, "_attribute_table.html", conn: @conn, data: @data %>
 </div>
 
 <%= if constraints != nil and map_size(constraints) > 0 do %>

--- a/server/lib/schema_web/templates/page/object.html.eex
+++ b/server/lib/schema_web/templates/page/object.html.eex
@@ -57,28 +57,7 @@ SPDX-License-Identifier: Apache-2.0
 <% else %>
 <div class="mt-4">
   <h5>Attributes</h5>
-  <table id="data-table" class="table table-bordered sortable">
-    <thead>
-      <tr class="thead-color">
-        <th class="col-name">Name</th>
-        <th class="col-caption">Caption</th>
-        <th class="col-requirement">Requirement</th>
-        <th class="col-type">Type</th>
-        <th class="col-description">Description</th>
-      </tr>
-    </thead>
-    <tbody class="searchable">
-      <%= for {attribute_key, attribute} <- @data[:attributes] do %>
-      <tr class="<%= field_classes(attribute)%>">
-        <td class="name" data-toggle="tooltip" title="<%= format_object_attribute_source(@data[:attribute_key], attribute) %>"><%= format_attribute_name(attribute_key) %></td>
-        <td><%= raw format_attribute_caption(@conn, attribute_key, attribute) %></td>
-        <td><%= raw format_requirement(constraints, attribute_key, attribute) %></td>
-        <td class="extensions"><%= raw format_type(@conn, attribute) %></td>
-        <td><%= raw format_attribute_desc(@conn, attribute_key, attribute) %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <%= render SchemaWeb.PageView, "_attribute_table.html", conn: @conn, data: @data %>
 </div>
 <% end %>
 

--- a/server/lib/schema_web/templates/page/objects.html.eex
+++ b/server/lib/schema_web/templates/page/objects.html.eex
@@ -7,7 +7,10 @@ SPDX-License-Identifier: Apache-2.0
   <div class="col-md move-up">
     <h3>Objects</h3>
     <div class="text-secondary description-content">
-      The OASF objects. An object is a complex data type, which is a collection of other attributes. Some objects represent entities or artifacts, but not all.
+      The OASF objects. An object is a complex data type, which is a collection of other attributes.
+    </div>
+    <div class="text-secondary description-content">
+      Record represents an agentic entity, while linkable objects are used to attach additional information to records.
     </div>
   </div>
   <div class="col-md-auto fixed-right mt-2">
@@ -21,29 +24,28 @@ SPDX-License-Identifier: Apache-2.0
   </div>
 </div>
 
-<div class="mt-4">
-  <table class="table table-bordered sortable">
-    <thead>
-      <tr class="thead-color">
-        <th class="col-name">Name</th>
-        <th class="col-caption">Caption</th>
-        <th class="col-references">Referenced By</th>
-        <th class="col-description">Description</th>
-      </tr>
-    </thead>
-    <tbody class="searchable">
-      <%= for {object_key, object} <- @data do %>
-        <% object_key_str = Atom.to_string(object_key) %>
-        <% object_path = Routes.static_path(@conn, "/objects/" <> object_key_str) %>
-        <tr class=<%= show_deprecated_css_classes(object, "oasf-class") %>" <%= raw format_profiles(object[:profiles])%>>
-          <td class="name"><a href="<%= object_path %>"><%= object_key_str %></a></td>
-          <td class="extensions"><%= raw format_attribute_caption(@conn, object_key_str, object) %></td>
-          <td class="extensions"><%= raw object_links(@conn, object[:name], object[:_links], :collapse) %></td>
-          <td><%= raw description(object) %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+<%!-- Partition objects into groups --%>
+<%
+  group_record = Enum.filter(@data, fn {_k, obj} -> obj[:name] == "record" end)
+  record_tuple = List.first(group_record)
+  record_object = record_tuple && elem(record_tuple, 1)
+  group_linkable = Enum.filter(@data, fn {_k, obj} -> obj[:extends] == "linkable" and obj[:name] != "record" end)
+  group_other = Enum.reject(@data, fn {_k, obj} -> obj[:name] == "record" or (obj[:extends] == "linkable" and obj[:name] != "record") end)
+%>
+
+<div class="object-section mt-4">
+  <h4><a href='<%= Routes.static_path(@conn, "/objects/record") %>'>Record Object</a></h4>
+  <%= render SchemaWeb.PageView, "_attribute_table.html", conn: @conn, data: record_object %>
+</div>
+
+<div class="object-section mt-4">
+  <h4>Linkable Objects</h4>
+  <%= render SchemaWeb.PageView, "_object_table.html", conn: @conn, objects: group_linkable %>
+</div>
+
+<div class="object-section mt-4">
+  <h4>Other Objects</h4>
+  <%= render SchemaWeb.PageView, "_object_table.html", conn: @conn, objects: group_other %>
 </div>
 
 <script>

--- a/server/priv/static/css/layout.css
+++ b/server/priv/static/css/layout.css
@@ -36,7 +36,7 @@
 
 .navbar-nav .nav-link.active {
   color: var(--accent-color);
-  font-weight: 500;
+  font-weight: 600;
   text-decoration: underline;
   text-underline-offset: 10px;
 }

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -18,7 +18,8 @@ import (
 const baseURL = "http://localhost:8080"
 
 type objectTestCase struct {
-	jsonPath           string
+	entityType         string
+	fileName           string
 	apiEndpoint        string
 	schemaEndpoint     string
 	sampleEndpoint     string
@@ -27,42 +28,48 @@ type objectTestCase struct {
 
 var testCases = []objectTestCase{
 	{
-		jsonPath:           "../../schema/objects/record.json",
+		entityType:         "objects",
+		fileName:           "record.json",
 		apiEndpoint:        baseURL + "/api/objects/record",
 		schemaEndpoint:     baseURL + "/schema/objects/record",
 		sampleEndpoint:     baseURL + "/sample/objects/record",
 		validationEndpoint: baseURL + "/api/validate/object/record",
 	},
 	{
-		jsonPath:           "../../schema/objects/locator.json",
+		entityType:         "objects",
+		fileName:           "locator.json",
 		apiEndpoint:        baseURL + "/api/objects/locator",
 		schemaEndpoint:     baseURL + "/schema/objects/locator",
 		sampleEndpoint:     baseURL + "/sample/objects/locator",
 		validationEndpoint: baseURL + "/api/validate/object/locator",
 	},
 	{
-		jsonPath:           "../../schema/objects/signature.json",
+		entityType:         "objects",
+		fileName:           "signature.json",
 		apiEndpoint:        baseURL + "/api/objects/signature",
 		schemaEndpoint:     baseURL + "/schema/objects/signature",
 		sampleEndpoint:     baseURL + "/sample/objects/signature",
 		validationEndpoint: baseURL + "/api/validate/object/signature",
 	},
 	{
-		jsonPath:           "../../schema/skills/base_skill.json",
+		entityType:         "skills",
+		fileName:           "base_skill.json",
 		apiEndpoint:        baseURL + "/api/skills/base_skill",
 		schemaEndpoint:     baseURL + "/schema/skills/base_skill",
 		sampleEndpoint:     baseURL + "/sample/skills/base_skill",
 		validationEndpoint: baseURL + "/api/validate/skill",
 	},
 	{
-		jsonPath:           "../../schema/domains/base_domain.json",
+		entityType:         "domains",
+		fileName:           "base_domain.json",
 		apiEndpoint:        baseURL + "/api/domains/base_domain",
 		schemaEndpoint:     baseURL + "/schema/domains/base_domain",
 		sampleEndpoint:     baseURL + "/sample/domains/base_domain",
 		validationEndpoint: baseURL + "/api/validate/domain",
 	},
 	{
-		jsonPath:           "../../schema/modules/base_module.json",
+		entityType:         "modules",
+		fileName:           "base_module.json",
 		apiEndpoint:        baseURL + "/api/modules/base_module",
 		schemaEndpoint:     baseURL + "/schema/modules/base_module",
 		sampleEndpoint:     baseURL + "/sample/modules/base_module",
@@ -75,11 +82,32 @@ var _ = Describe("API", func() {
 		for _, tc := range testCases {
 			tc := tc
 			It("should match API response with expected JSON for "+tc.apiEndpoint, func() {
-				expectedBytes, err := os.ReadFile(tc.jsonPath)
+				jsonPath := "../../schema/" + tc.entityType + "/" + tc.fileName
+				expectedBytes, err := os.ReadFile(jsonPath)
 				Expect(err).NotTo(HaveOccurred(), "Failed to read expected JSON file")
 
 				var expected map[string]interface{}
 				Expect(json.Unmarshal(expectedBytes, &expected)).To(Succeed(), "Failed to unmarshal expected JSON")
+
+				// Handle extends
+				if ext, ok := expected["extends"].(string); ok && ext != "" {
+					extendsPath := "../../schema/" + tc.entityType + "/" + ext + ".json"
+					extendsBytes, err := os.ReadFile(extendsPath)
+					Expect(err).NotTo(HaveOccurred(), "Failed to read extended JSON file")
+					var parent map[string]interface{}
+					Expect(json.Unmarshal(extendsBytes, &parent)).To(Succeed(), "Failed to unmarshal extended JSON")
+					// Merge attributes: parent first, then child (child overrides)
+					parentAttrs, _ := parent["attributes"].(map[string]interface{})
+					childAttrs, _ := expected["attributes"].(map[string]interface{})
+					mergedAttrs := map[string]interface{}{}
+					for k, v := range parentAttrs {
+						mergedAttrs[k] = v
+					}
+					for k, v := range childAttrs {
+						mergedAttrs[k] = v
+					}
+					expected["attributes"] = mergedAttrs
+				}
 
 				resp, err := http.Get(tc.apiEndpoint)
 				Expect(err).NotTo(HaveOccurred(), "Failed to GET API")

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -42,10 +42,10 @@ var testCases = []objectTestCase{
 	},
 	{
 		jsonPath:           "../../schema/objects/signature.json",
-		apiEndpoint:        baseURL + "/api/objects/record_signature",
-		schemaEndpoint:     baseURL + "/schema/objects/record_signature",
-		sampleEndpoint:     baseURL + "/sample/objects/record_signature",
-		validationEndpoint: baseURL + "/api/validate/object/record_signature",
+		apiEndpoint:        baseURL + "/api/objects/signature",
+		schemaEndpoint:     baseURL + "/schema/objects/signature",
+		sampleEndpoint:     baseURL + "/sample/objects/signature",
+		validationEndpoint: baseURL + "/api/validate/object/signature",
 	},
 	{
 		jsonPath:           "../../schema/skills/base_skill.json",

--- a/test/proto/proto_test.go
+++ b/test/proto/proto_test.go
@@ -170,7 +170,7 @@ func compareSchemas(jsonSchema JsonSchema, protoMessage ProtoMessage) ([]string,
 
 var _ = Describe("JsonSchema and Proto synchronization", func() {
 	schemaRoot := "../../schema/"
-	protoRoot := "../../proto/agntcy/oasf/types/v1alpha1/"
+	protoRoot := "../../proto/agntcy/oasf/types/v1alpha2/"
 
 	type testCase struct {
 		jsonPath  string


### PR DESCRIPTION
- removed Record navbar menu item
- Objects page as default page for OASF
- rearranged Objects page to have separate sections for the Record and linkable objects
- created `linkable` object type with `schema_version` and `parent_cid` attributes, "top level" objects such as `record` and `signature` extend from that
  - parent_cid in `record` could be used to link it to the previous record
  - parent_cid in other linkable objects such as `signature` can be used to link them to records
- added proto v1alpha2 files

Fixes #312 

| Before | After |
| -------|------|
|  <img width="1527" height="1310" alt="Screenshot 2025-09-25 at 13 56 58" src="https://github.com/user-attachments/assets/353921db-9d16-4af1-ad50-e68fe19f6b72" /> | <img width="1527" height="1310" alt="Screenshot 2025-09-25 at 13 57 25" src="https://github.com/user-attachments/assets/18c4df1b-cfe8-4bfc-ba9b-134d5c5eac85" /> |

