### PR TITLE
feat(schema, server): reorganize modules

### DIFF
--- a/schema/module_categories.json
+++ b/schema/module_categories.json
@@ -3,25 +3,15 @@
   "description": "A comprehensive table outlining module sets of application and knowledge areas within the framework.",
   "name": "module_categories",
   "attributes": {
-    "observability": {
+    "core": {
       "uid": 1,
-      "caption": "Observability",
-      "description": "Observability module set."
-    },
-    "evaluation": {
-      "uid": 2,
-      "caption": "Evaluation",
-      "description": "Evaluation module set."
+      "caption": "Core",
+      "description": "Core AGNTCY modules."
     },
     "runtime": {
-      "uid": 3,
+      "uid": 2,
       "caption": "Runtime",
       "description": "Runtime module set."
-    },
-    "identity": {
-      "uid": 4,
-      "caption": "Identity",
-      "description": "Identity module set."
     }
   }
 }

--- a/schema/modules/core/core.json
+++ b/schema/modules/core/core.json
@@ -1,0 +1,8 @@
+{
+  "caption": "Core",
+  "description": "Core AGNTCY modules.",
+  "extends": "base_module",
+  "name": "core",
+  "category": "core",
+  "attributes": {}
+}

--- a/schema/modules/core/llm/llm.json
+++ b/schema/modules/core/llm/llm.json
@@ -1,0 +1,8 @@
+{
+  "uid": 2,
+  "caption": "LLM",
+  "description": "Modules for basic LLM functionality.",
+  "extends": "core",
+  "name": "llm",
+  "attributes": {}
+}

--- a/schema/modules/core/llm/model.json
+++ b/schema/modules/core/llm/model.json
@@ -1,8 +1,8 @@
 {
-  "uid": 3,
+  "uid": 1,
   "caption": "LLM Model",
   "description": "Describes LLM support and its configuration for a given agent.",
-  "extends": "runtime",
+  "extends": "llm",
   "name": "model",
   "attributes": {
     "data": {

--- a/schema/modules/core/llm/prompt.json
+++ b/schema/modules/core/llm/prompt.json
@@ -1,8 +1,8 @@
 {
-  "uid": 4,
+  "uid": 2,
   "caption": "LLM Prompt",
   "description": "Describes common LLM interaction prompts to use the agent.",
-  "extends": "runtime",
+  "extends": "llm",
   "name": "prompt",
   "attributes": {
     "data": {

--- a/schema/modules/core/observability.json
+++ b/schema/modules/core/observability.json
@@ -2,8 +2,7 @@
   "uid": 1,
   "caption": "Observability",
   "description": "A module describing how the agent can be observed.",
-  "category": "observability",
-  "extends": "base_module",
+  "extends": "core",
   "name": "observability",
   "attributes": {
     "data": {

--- a/schema/modules/identity/identity.json
+++ b/schema/modules/identity/identity.json
@@ -1,8 +1,0 @@
-{
-  "caption": "Identity",
-  "description": "Identity feature set",
-  "extends": "base_module",
-  "name": "identity",
-  "category": "identity",
-  "attributes": {}
-}

--- a/schema/modules/runtime/a2a.json
+++ b/schema/modules/runtime/a2a.json
@@ -1,5 +1,5 @@
 {
-  "uid": 5,
+  "uid": 3,
   "caption": "A2A",
   "description": "Describes A2A card details for communication and usage with A2A protocol.",
   "extends": "runtime",

--- a/schema/modules/runtime/manifest.json
+++ b/schema/modules/runtime/manifest.json
@@ -11,5 +11,9 @@
       "description": "Data supported by the agent for runtime manifest.",
       "requirement": "required"
     }
+  },
+  "@deprecated": {
+    "message": "ACP is deprecated, please use A2A instead.",
+    "since": "0.8.0"
   }
 }

--- a/server/lib/schema_web/templates/page/dictionary.html.eex
+++ b/server/lib/schema_web/templates/page/dictionary.html.eex
@@ -14,8 +14,8 @@ SPDX-License-Identifier: Apache-2.0
     <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
     <div class="mt-3">
       <div class="btn-group d-flex" role="group" aria-label="Dictionary actions">
-        <button type="button" title="Expand all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
-        <button type="button" title="Collapse all references" class="btn btn-sm btn-outline-primary" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
+        <button type="button" title="Expand all references" class="btn btn-sm btn-outline-primary view-toggle-btn" onclick="$('.multi-collapse').collapse('show');">Expand All</button>
+        <button type="button" title="Collapse all references" class="btn btn-sm btn-outline-primary view-toggle-btn active" onclick="$('.multi-collapse').collapse('hide');">Collapse All</button>
       </div>
     </div>
   </div>

--- a/server/lib/schema_web/templates/page/index.html.eex
+++ b/server/lib/schema_web/templates/page/index.html.eex
@@ -12,6 +12,12 @@ SPDX-License-Identifier: Apache-2.0
   </div>
   <div class="navbar-nav col-md-auto fixed-right mt-2">
     <input type="text" id="tableSearch" onkeyup="searchInTable()" class="form-control border-dark" placeholder="Search" autofocus>
+    <div class="mt-3">
+      <div class="btn-group d-flex" role="group" aria-label="View actions">
+        <button type="button" class="btn btn-sm btn-outline-primary view-toggle-btn" data-view="card">Card view</button>
+        <button type="button" class="btn btn-sm btn-outline-primary view-toggle-btn active" data-view="taxonomy">Taxonomy view</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/server/lib/schema_web/templates/page/index.html.eex
+++ b/server/lib/schema_web/templates/page/index.html.eex
@@ -21,21 +21,45 @@ SPDX-License-Identifier: Apache-2.0
   </div>
 </div>
 
-<div class="mt-3 multi-col">
-  <%= for {category_key, category} <- @data[:attributes] do %>
-  <% category_key_str = Atom.to_string(category_key) %>
-  <% category_path = Routes.static_path(@conn, "/"<> @data[:categories_path] <> "/" <> category_key_str) %>
-  <section class="category">
-    <header><a href="<%= category_path %>"><%= raw format_caption(category_key_str, category) %></a></header>
-    <%= for {class_key, class} <- category[:classes] do %>
-    <% class_key_str = Atom.to_string(class_key) %>
-    <% class_path = Routes.static_path(@conn, "/" <> @data[:classes_path] <> "/" <> class_key_str) %>
-    <div class="<%= show_deprecated_css_classes(class, "oasf-class") %> <%= indent_class(class) %>" <%= raw format_profiles(class[:profiles])%>>
-      <%= raw format_linked_class_caption(class_path, class_key_str, class) %>
-    </div>
+<div id="taxonomy-view">
+  <div class="mt-3 multi-col">
+    <%= for {category_key, category} <- @data[:attributes] do %>
+    <% category_key_str = Atom.to_string(category_key) %>
+    <% category_path = Routes.static_path(@conn, "/"<> @data[:categories_path] <> "/" <> category_key_str) %>
+    <section class="category">
+      <header><a href="<%= category_path %>"><%= raw format_caption(category_key_str, category) %></a></header>
+      <%= for {class_key, class} <- category[:classes] do %>
+      <% class_key_str = Atom.to_string(class_key) %>
+      <% class_path = Routes.static_path(@conn, "/" <> @data[:classes_path] <> "/" <> class_key_str) %>
+      <div class="<%= show_deprecated_css_classes(class, "oasf-class") %> <%= indent_class(class) %>" <%= raw format_profiles(class[:profiles])%>>
+        <%= raw format_linked_class_caption(class_path, class_key_str, class) %>
+      </div>
+      <% end %>
+    </section>
     <% end %>
-  </section>
-  <% end %>
+  </div>
+</div>
+
+<div id="card-view" style="display:none">
+  <div class="mt-3 multi-col">
+    <%= for {_category_key, category} <- @data[:attributes],
+           {_class_key, class} <- category[:classes] do %>
+      <section class="<%= show_deprecated_css_classes(class, "category card-category") %>">
+        <header class="d-flex justify-content-between align-items-center">
+          <% class_path = SchemaWeb.PageView.class_path(@conn, class) %>
+          <span>
+            <%= raw format_linked_class_caption(class_path, class[:name], class) %>
+          </span>
+          <a href="<%= Routes.static_path(@conn, "/" <> @data[:categories_path] <> "/" <> class[:category]) %>" class="text-muted ml-2">
+            <%= class[:category_name] %>
+          </a>
+        </header>
+        <div class="description-content">
+          <%= class[:description] %>
+        </div>
+      </section>
+    <% end %>
+  </div>
 </div>
 
 <script>

--- a/server/priv/static/css/components.css
+++ b/server/priv/static/css/components.css
@@ -208,6 +208,18 @@ button:hover,
   margin-right: var(--spacing-xs);
 }
 
+.view-toggle-btn.active {
+  background: var(--primary-color);
+  color: var(--text-inverse);
+  border-color: var(--primary-color);
+}
+
+.view-toggle-btn:focus,
+.view-toggle-btn.active:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
 /* Show Deprecated Button */
 .show-deprecated-container {
   display: flex;

--- a/server/priv/static/js/app.js
+++ b/server/priv/static/js/app.js
@@ -544,3 +544,15 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 });
+
+document.addEventListener("DOMContentLoaded", function () {
+  const buttons = document.querySelectorAll(".view-toggle-btn");
+  if (buttons.length === 2) {
+    buttons.forEach((btn) => {
+      btn.addEventListener("click", function () {
+        buttons.forEach((b) => b.classList.remove("active"));
+        this.classList.add("active");
+      });
+    });
+  }
+});

--- a/server/priv/static/js/app.js
+++ b/server/priv/static/js/app.js
@@ -556,3 +556,24 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 });
+
+document.addEventListener("DOMContentLoaded", function () {
+  const buttons = document.querySelectorAll(".view-toggle-btn");
+  const cardView = document.getElementById("card-view");
+  const taxonomyView = document.getElementById("taxonomy-view");
+  if (buttons.length === 2 && cardView && taxonomyView) {
+    buttons.forEach(btn => {
+      btn.addEventListener("click", function () {
+        buttons.forEach(b => b.classList.remove("active"));
+        this.classList.add("active");
+        if (this.dataset.view === "card") {
+          cardView.style.display = "";
+          taxonomyView.style.display = "none";
+        } else {
+          cardView.style.display = "none";
+          taxonomyView.style.display = "";
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
- deprecated Manifest module
- reorganized modules in new module categories
- added card view option on the classes pages

| **Taxonomy view** | **Card view** |
| ----------- | -------- |
| <img width="1498" height="829" alt="Screenshot 2025-10-01 at 17 21 14" src="https://github.com/user-attachments/assets/570f6932-3338-4f88-b141-fb4719913b01" /> | <img width="1498" height="829" alt="Screenshot 2025-10-01 at 17 21 20" src="https://github.com/user-attachments/assets/1debc303-b104-46d6-ab24-91b0713d625c" /> |
| <img width="1498" height="829" alt="Screenshot 2025-10-01 at 17 21 46" src="https://github.com/user-attachments/assets/114ffa79-2b45-4bbe-8283-22c25fdeccb3" /> | <img width="1498" height="829" alt="Screenshot 2025-10-01 at 17 21 52" src="https://github.com/user-attachments/assets/20aa0fc4-e56a-493b-bed7-e8cbf8bd0f60" /> |



