### PR TITLE
ci: add git diff log when format is checked

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,8 @@ on:
     branches:
       - main
     tags:
-      - "v*.*.*"
-      - "helm/v*.*.*"
+      - 'v*.*.*'
+      - 'helm/v*.*.*'
   pull_request:
 
 permissions:
@@ -64,6 +64,7 @@ jobs:
       - name: Check code changes
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
+            git diff
             echo "There are uncommitted changes after running 'task fmt'. Please commit these changes."
             exit 1
           fi


### PR DESCRIPTION
This change add a git diff output when the formatting is found a change which is not commited to the branch.