### PR TITLE
fix: add cid_t type so previous_record_cid

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -338,7 +338,7 @@
     "description": {
       "caption": "Description",
       "description": "The description of the entity. See specific usage.",
-      "type": "string_t"
+      "type": "long_string_t"
     },
     "digest": {
       "caption": "Digest",
@@ -709,6 +709,7 @@
       "email_t": {
         "caption": "Email Address",
         "description": "Email address. For example:<br><code>john_doe@example.com</code>.",
+        "max_len": 320,
         "regex": "^[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
         "type": "string_t",
         "type_name": "String"
@@ -716,6 +717,7 @@
       "file_hash_t": {
         "caption": "Hash",
         "description": "Hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema. For example:<br> MD5: <code>3172ac7e2b55cbb81f04a6e65855a628</code>.",
+        "max_len": 71,
         "regex": "^sha256:[a-fA-F0-9]+$",
         "type": "string_t",
         "type_name": "String"
@@ -723,6 +725,7 @@
       "file_name_t": {
         "caption": "File Name",
         "description": "File name. For example:<br><code>text-file.txt</code>.",
+        "max_len": 255,
         "type": "string_t",
         "type_name": "String"
       },
@@ -745,6 +748,13 @@
       "json_t": {
         "caption": "JSON",
         "description": "Embedded JSON value. A value can be a string, or a number, or true or false or null, or an object or an array. These structures can be nested. See <a target='_blank' href='https://www.json.org'>www.json.org</a>."
+      },
+      "long_string_t": {
+        "caption": "Long String",
+        "description": "A string type for longer text content such as descriptions, documentation, or detailed metadata. Supports up to 10,000 characters.",
+        "max_len": 10000,
+        "type": "string_t",
+        "type_name": "String"
       },
       "long_t": {
         "caption": "Long",
@@ -789,7 +799,8 @@
       },
       "string_t": {
         "caption": "String",
-        "description": "UTF-8 encoded byte sequence."
+        "description": "UTF-8 encoded byte sequence.",
+        "max_len": 2000
       },
       "subnet_t": {
         "max_len": 42,
@@ -833,6 +844,7 @@
       "username_t": {
         "caption": "User Name",
         "description": "User name. For example:<br><code>john_doe</code>.",
+        "max_len": 64,
         "type": "string_t",
         "type_name": "String"
       },

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -524,6 +524,7 @@ defmodule Schema.Generator do
   defp generate_data(_name, "unit_interval_t", _field), do: unit_interval()
   defp generate_data(_name, "uuid_t", _field), do: uuid()
   defp generate_data(_name, "cid_t", _field), do: cid()
+  defp generate_data(_name, "long_string_t", _field), do: sentence(20)
   defp generate_data(_name, "ip_t", _field), do: ipv4()
   defp generate_data(_name, "subnet_t", _field), do: subnet()
   defp generate_data(_name, "mac_t", _field), do: mac()

--- a/server/lib/schema/types.ex
+++ b/server/lib/schema/types.ex
@@ -51,6 +51,7 @@ defmodule Schema.Types do
       "datetime_t" -> "string"
       "uuid_t" -> "string"
       "cid_t" -> "string"
+      "long_string_t" -> "string"
       "email_t" -> "string"
       "url_t" -> "string"
       "ip_t" -> "string"


### PR DESCRIPTION
Created new `cid_t` type so the `previous_record_cid` attribute gets generated and validated properly.
Also added max length constraint to string attributes.

Fixes #347 
Fixes #337 