### PR TITLE
feat(schema): extend agent spec module to support deployment options

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -228,6 +228,27 @@
       "description": "This is `true` if the agent supports run threads. If this is `false`, then the threads tagged with `Threads` are not available. If missing, it means `false`.",
       "type": "boolean_t"
     },
+    "agentspec_communication_protocol": {
+      "caption": "Communication Protocol Configuration",
+      "description": "Configuration for the protocol used to serve the Agent.",
+      "type": "agentspec_communication_protocol",
+      "is_enum": true
+    },
+    "agentspec_communication_protocol_a2a": {
+      "caption": "Communication Protocol Configuration A2A",
+      "description": "Configuration for the A2A-compatible agent endpoint.",
+      "type": "agentspec_communication_protocol_a2a"
+    },
+    "agentspec_communication_protocol_data": {
+      "caption": "Communication Protocol Data",
+      "description": "Configuration data for the communication protocol (e.g., urls, protocol versions)",
+      "type": "json_t"
+    },
+    "agentspec_communication_protocol_responses_api": {
+      "caption": "Communication Protocol Configuration Responses API",
+      "description": "Configuration for the Responses API-compatible agent endpoint.",
+      "type": "agentspec_communication_protocol_responses_api"
+    },
     "agentspec_config": {
       "caption": "Config Locator",
       "description": "Describes the location of the Agent Spec configuration.",
@@ -243,6 +264,12 @@
           "url": "https://oracle.github.io/agent-spec/agentspec/language_spec_25_4_1.html"
         }
       ]
+    },
+    "agentspec_deployment_options": {
+      "caption": "Deployment Options",
+      "description": "List of possible configuration to instantiate or consume the agent. Any of the available option could be used.",
+      "type": "agentspec_deployment_option",
+      "is_array": true
     },
     "agentspec_runtime_deps": {
       "caption": "Runtime Dependencies",

--- a/schema/objects/agentspec_communication_protocol.json
+++ b/schema/objects/agentspec_communication_protocol.json
@@ -1,0 +1,7 @@
+{
+  "caption": "Communication Protocol Configuration",
+  "description": "Configuration for the protocol used to serve the Agent.",
+  "extends": "object",
+  "name": "agentspec_communication_protocol",
+  "attributes": {}
+}

--- a/schema/objects/agentspec_communication_protocol_a2a.json
+++ b/schema/objects/agentspec_communication_protocol_a2a.json
@@ -1,0 +1,28 @@
+{
+  "caption": "Communication Protocol Configuration A2A",
+  "description": "Configuration for the A2A-compatible agent endpoint.",
+  "extends": "agentspec_communication_protocol",
+  "name": "agentspec_communication_protocol_a2a",
+  "attributes": {
+    "type": {
+      "caption": "Type",
+      "description": "Communication protocol type.",
+      "requirement": "required",
+      "enum": {
+        "A2A": {
+          "caption": "A2A"
+        }
+      }
+    },
+    "url": {
+      "description": "URL of the agent endpoint.",
+      "requirement": "required"
+    },
+    "protocol_version": {
+      "reference": "a2a_protocol_version",
+      "caption": "Protocol Version",
+      "description": "Version of the A2A protocol used by the agent.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/objects/agentspec_communication_protocol_responses_api.json
+++ b/schema/objects/agentspec_communication_protocol_responses_api.json
@@ -1,0 +1,27 @@
+{
+  "caption": "Communication Protocol Configuration Responses API",
+  "description": "Configuration for the Responses API-compatible agent endpoint.",
+  "extends": "agentspec_communication_protocol",
+  "name": "agentspec_communication_protocol_responses_api",
+  "attributes": {
+    "type": {
+      "caption": "Type",
+      "description": "Communication protocol type.",
+      "requirement": "required",
+      "enum": {
+        "Responses_API": {
+          "caption": "Responses API"
+        }
+      }
+    },
+    "url": {
+      "description": "URL of the agent endpoint.",
+      "requirement": "required"
+    },
+    "model": {
+      "caption": "Model/Agent Identifier",
+      "description": "Model/Agent identifier for the Response API-compatible agent endpoint. If missing, will use the agent name as specified in the agent record.",
+      "requirement": "optional"
+    }
+  }
+}

--- a/schema/objects/agentspec_data.json
+++ b/schema/objects/agentspec_data.json
@@ -10,16 +10,21 @@
       "description": "Location of the Agent Spec config. E.g. path to config, github repo url etc.",
       "requirement": "required"
     },
-    "runtime_framework": {
-      "reference": "agentspec_runtime_framework",
-      "caption": "Runtime Framework",
-      "description": "Name for the runtime framework to use to run the Agent Spec config.",
+    "deployment_options": {
+      "reference": "agentspec_deployment_options",
+      "caption": "Deployment Options",
+      "description": "List of possible configuration to instantiate or consume the agent. Any of the available option could be used.",
       "requirement": "required"
     },
     "runtime_deps": {
       "reference": "agentspec_runtime_deps",
       "caption": "Runtime Dependencies",
       "description": "List of locators for the non-serializable objects the Agent Spec config depends on (e.g. tool implementations).",
+      "requirement": "optional"
+    },
+    "env_vars": {
+      "caption": "Environment Variables",
+      "description": "List of environment variables to be set for the agent.",
       "requirement": "optional"
     }
   },

--- a/schema/objects/agentspec_deployment_option.json
+++ b/schema/objects/agentspec_deployment_option.json
@@ -1,0 +1,25 @@
+{
+  "caption": "Deployment Option",
+  "description": "Describes a deployment option for an agent.",
+  "extends": "object",
+  "name": "agentspec_deployment_option",
+  "attributes": {
+    "name": {
+      "caption": "Deployment Option Name",
+      "description": "Name of the deployment option.",
+      "requirement": "optional"
+    },
+    "protocol": {
+      "reference": "agentspec_communication_protocol",
+      "caption": "Communication Protocol Configuration",
+      "description": "Configuration for the protocol used to serve the Agent.",
+      "requirement": "required"
+    },
+    "runtime_framework": {
+      "reference": "agentspec_runtime_framework",
+      "caption": "Runtime Framework",
+      "description": "Name for the runtime framework to use to run the Agent Spec config.",
+      "requirement": "required"
+    }
+  }
+}


### PR DESCRIPTION
# Context

In this PR we extend the Agent Spec module to enable assistant developers to provide and store information about how an agent can be instantiated or consumed (including what are the preferred runtime framework / serving protocol and required environment variables to run the agent), including:

- What are the preferred agent communication protocols (e.g. A2A, Responses API)
- What are the required environment variables

See the discussion in https://github.com/agntcy/oasf/issues/352
