### PR TITLE
feat(schema): add evaluation module back

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -391,6 +391,22 @@
       "type": "env_var",
       "is_array": true
     },
+    "evaluation_data": {
+      "caption": "Data",
+      "description": "Data supported by the agent for evaluation.",
+      "type": "evaluation_data"
+    },
+    "evaluation_datasets": {
+      "caption": "Datasets",
+      "description": "Datasets array.",
+      "type": "evaluation_dataset",
+      "is_array": true
+    },
+    "evaluation_report": {
+      "caption": "Evaluation report",
+      "description": "The report of an evaluation.",
+      "type": "evaluation_report"
+    },
     "export_format": {
       "caption": "Export Format",
       "description": "Format used by the agent for exporting observability data.",
@@ -505,6 +521,18 @@
       "type": "mcp_server_tool",
       "is_array": true
     },
+    "metadata": {
+      "caption": "Metadata",
+      "description": "Metadata associated with the object. See specific usage.",
+      "type": "key_value_object",
+      "is_array": true
+    },
+    "metrics": {
+      "caption": "Metrics",
+      "description": "Defines the key metrics used to evaluate system performance, cost, and other critical factors.",
+      "type": "metric",
+      "is_array": true
+    },
     "mime_type": {
       "caption": "MIME Type",
       "description": "The MIME type of the content. For example: <code>application/json</code>, <code>text/plain</code>.",
@@ -566,6 +594,16 @@
         }
       ]
     },
+    "overall_rating": {
+      "caption": "Overall Rating",
+      "description": "Overall rating.",
+      "type": "float_t"
+    },
+    "overall_scores": {
+      "caption": "Overall Scores",
+      "description": "Overall scores of the Agent across all evaluation.",
+      "type": "overall_scores"
+    },
     "path": {
       "caption": "Path",
       "description": "The path that pertains to the class or object. See specific usage.",
@@ -586,10 +624,21 @@
       "description": "Name of the provider of a service, tool, object, etc. See specific usage.",
       "type": "string_t"
     },
+    "publisher": {
+      "caption": "Publisher",
+      "description": "Data publisher. See specific usage.",
+      "type": "publisher"
+    },
     "quality_score": {
       "caption": "Quality Score",
       "description": "Overall score.",
       "type": "float_t"
+    },
+    "referred_evaluations": {
+      "caption": "Referred evaluations",
+      "description": "Evaluations associated to the Agent.",
+      "type": "referred_evaluation",
+      "is_array": true
     },
     "required": {
       "caption": "Required",

--- a/schema/modules/core/evaluation.json
+++ b/schema/modules/core/evaluation.json
@@ -1,0 +1,15 @@
+{
+  "uid": 3,
+  "caption": "Evaluation",
+  "description": "Assessing actions and outcomes to determine their effectiveness, guiding future decision-making and enhancing personal agency.",
+  "extends": "core",
+  "name": "evaluation",
+  "attributes": {
+    "data": {
+      "reference": "evaluation_data",
+      "caption": "Data",
+      "description": "Data supported by the agent for evaluation.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/objects/evaluation_data.json
+++ b/schema/objects/evaluation_data.json
@@ -1,0 +1,23 @@
+{
+  "caption": "Evaluation Data",
+  "description": "Data supported by the record module for evaluation.",
+  "extends": "module_data",
+  "name": "evaluation_data",
+  "attributes": {
+    "overall_rating": {
+      "caption": "Overall Rating",
+      "description": "Overall rating of the agent across all evaluation.",
+      "requirement": "optional"
+    },
+    "overall_scores": {
+      "caption": "Overall Scores",
+      "description": "Overall scores of the agent across all evaluation.",
+      "requirement": "optional"
+    },
+    "referred_evaluations": {
+      "caption": "Referred Evaluations",
+      "description": "Evaluations associated to the agent.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/objects/evaluation_dataset.json
+++ b/schema/objects/evaluation_dataset.json
@@ -1,0 +1,27 @@
+{
+  "caption": "Dataset",
+  "description": "A dataset used for agent evaluation.",
+  "name": "evaluation_dataset",
+  "attributes": {
+    "url": {
+      "caption": "URL",
+      "description": "The URL pointing to the actual dataset.",
+      "requirement": "required"
+    },
+    "name": {
+      "caption": "Name",
+      "description": "The name of the dataset.",
+      "requirement": "required"
+    },
+    "version": {
+      "caption": "Version",
+      "description": "The version of the dataset.",
+      "requirement": "recommended"
+    },
+    "metadata": {
+      "caption": "Metadata",
+      "description": "The metadata associated to the dataset.",
+      "requirement": "optional"
+    }
+  }
+}

--- a/schema/objects/evaluation_report.json
+++ b/schema/objects/evaluation_report.json
@@ -1,0 +1,23 @@
+{
+  "caption": "Evaluation report",
+  "description": "The report of an evaluation.",
+  "name": "evaluation_report",
+  "attributes": {
+    "overall_scores": {
+      "caption": "Scores",
+      "description": "The scores of the associated evaluation.",
+      "requirement": "recommended"
+    },
+    "metrics": {
+      "caption": "Metrics",
+      "description": "The metrics of the associated evaluation.",
+      "requirement": "recommended"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "overall_scores",
+      "metrics"
+    ]
+  }
+}

--- a/schema/objects/referred_evaluation.json
+++ b/schema/objects/referred_evaluation.json
@@ -1,0 +1,34 @@
+{
+  "caption": "Referred Evaluation",
+  "description": "Referred evaluation for an agent.",
+  "name": "referred_evaluation",
+  "attributes": {
+    "datasets": {
+      "reference": "evaluation_datasets",
+      "caption": "Datasets",
+      "description": "The datasets used for this evaluation.",
+      "requirement": "recommended"
+    },
+    "publisher": {
+      "caption": "Evaluation Publisher",
+      "description": "The entity that published this evaluation.",
+      "requirement": "required"
+    },
+    "created_at": {
+      "caption": "Creation Date",
+      "description": "Creation date of this evaluation.",
+      "requirement": "required"
+    },
+    "evaluation_report": {
+      "caption": "Evaluation Report",
+      "description": "The report of this evaluation.",
+      "requirement": "recommended"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "datasets",
+      "evaluation_report"
+    ]
+  }
+}


### PR DESCRIPTION
Added back the evaluation module that was removed a while ago. I changed the requirement levels, and added `at_least_one` constraints on some of the fields where I thought it might make sense compared to the original one.

Closes #385 