### PR TITLE
fix(schema): versioned link to A2A AgentCard proto spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ true`
    "references": [
      {
        "description": "A2A Card Data Schema",
-       "url": "https://github.com/google-a2a/A2A/blob/main/docs/specification.md#55-agentcard-object-structure"
+       "url": "https://github.com/a2aproject/A2A/blob/v0.3.0/specification/grpc/a2a.proto"
      }
    ]
    ```
@@ -261,7 +261,7 @@ true`
     "references": [
       {
         "description": "A2A Card Data Schema",
-        "url": "https://github.com/google-a2a/A2A/blob/main/docs/specification.md#55-agentcard-object-structure"
+        "url": "https://github.com/a2aproject/A2A/blob/v0.3.0/specification/grpc/a2a.proto"
       }
     ]
     ```

--- a/schema/objects/a2a_data.json
+++ b/schema/objects/a2a_data.json
@@ -12,7 +12,7 @@
       "references": [
         {
           "description": "A2A AgentCard Proto Message",
-          "url": "https://github.com/google-a2a/A2A/blob/main/specification/grpc/a2a.proto"
+          "url": "https://github.com/a2aproject/A2A/blob/v0.3.0/specification/grpc/a2a.proto"
         }
       ]
     },


### PR DESCRIPTION
Replaced link to A2A proto specification to point to specific git tag (and also changed the repo it points to).

Fixes #408 