### PR TITLE
fix(schema): fix uuid example typo

### DIFF
--- a/schema/dictionary.json
+++ b/schema/dictionary.json
@@ -955,7 +955,7 @@
       },
       "uuid_t": {
         "caption": "UUID",
-        "description": "128-bit universal unique identifier. For example:<br><code>123e4567-e89b-12d3-a456-42661417400</code>.",
+        "description": "128-bit universal unique identifier. For example:<br><code>123e4567-e89b-12d3-a456-426614174000</code>.",
         "regex": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
         "type": "string_t",
         "type_name": "String"


### PR DESCRIPTION
| Scope | Complexity |
| - | - |
| patch | trivial |

### What & Why

1. Fixed a typo in the uuid_t example value, it was originally missing a character from the last 12 character segment.