### PR TITLE
Reserve agentminds_io extension namespace

### DIFF
--- a/schema/extensions/agentminds_io/README.md
+++ b/schema/extensions/agentminds_io/README.md
@@ -1,0 +1,42 @@
+# `agentminds_io` extension namespace
+
+**Owner:** AgentMinds — https://agentminds.dev
+**Contact:** fabrecamimarlik@gmail.com
+**Reserved:** 2026-04-27
+**License:** CC-BY-4.0 (extension definitions); MIT (reference code)
+**Spec:** https://github.com/agentmindsdev/profile
+
+## Purpose
+
+Reserve the `agentminds_io` extension namespace for AgentMinds-
+specific OASF record fields that have no canonical equivalent in
+the upstream OASF schema. AgentMinds operates a cross-site agent
+intelligence pool; the fields below describe state that only has
+meaning across organisations.
+
+## Initial extension fields
+
+| Field | Type | Description |
+|---|---|---|
+| `agentminds_io.pattern.id` | string | Cross-site pattern identifier (lowercase hex SHA-256, 64 chars) |
+| `agentminds_io.pattern.fingerprint` | string | Alias of `.id` for Sentry-style readers |
+| `agentminds_io.pattern.confidence` | float [0,1] | Beta-Bernoulli posterior confidence |
+| `agentminds_io.pattern.cross_site_seen_count` | int | Distinct sites that observed this pattern |
+| `agentminds_io.pattern.last_verified` | RFC3339 | Last network-wide confirmation timestamp |
+| `agentminds_io.pattern.volatility_class` | enum (`stable`/`evolving`/`decaying`) | Drift detection signal |
+| `agentminds_io.report.profile_version` | semver | ARP version this report follows |
+
+## Reorientation clause
+
+Per the AgentMinds Reporting Profile (ARP) §7, if a future canonical
+OASF version introduces a cross-site pool concept that absorbs these
+fields, AgentMinds will defer to the canonical definitions. This
+extension namespace becomes a backwards-compatible alias.
+
+## Reference
+
+- AgentMinds Reporting Profile (ARP):
+  https://github.com/agentmindsdev/profile
+- Reference implementation:
+  https://github.com/agentmindsdev/agentminds (closed-source;
+  excerpts available on request)


### PR DESCRIPTION
## Summary

Reserves the `agentminds_io` extension namespace for AgentMinds-
specific OASF record fields. Lays the groundwork for a follow-up
PR proposing OASF Skill 1106 ("Cross-Site Pattern Confidence")
under Category 11 (Evaluation & Monitoring).

## Why this is needed

AgentMinds (https://agentminds.dev) operates a cross-site agent
intelligence pool — patterns and recommendations are aggregated
across a network of registered sites and delivered back to each
connected site filtered by its specific stack.

The state describing cross-site aggregation (Beta-Bernoulli
confidence, seen counts across sites, last-verified timestamps,
drift / volatility classes) does not have a canonical OASF
equivalent today. Per AGNTCY's contribution practice, vendors
reserve a namespace before publishing records that use vendor-
specific fields.

## What this PR adds

A single file `schema/extensions/agentminds_io/README.md`
declaring:

- Owner, contact, license
- The seven initial extension fields with types + descriptions
- A reorientation clause that defers to canonical OASF if a
  future version absorbs cross-site pool concepts

## What this PR does NOT add

- No schema changes to `schema/objects/`
- No new skill taxonomy IDs (those will land in a follow-up PR)
- No reference code

## Companion submissions (planned)

1. **OASF Skill 1106 — Cross-Site Pattern Confidence** under
   Category 11. Schema fragment ready; waiting for this namespace
   PR to merge.
2. **MCP SEP "Cross-Site Audit Trails for Tool Invocations"** —
   the same primitive at the MCP layer.

## Reference implementation

The fields are already in production at AgentMinds. Reference
implementation:

- ARP fingerprint helper (Python):
  https://github.com/agentmindsdev/profile (canonical spec at
  AGENT_REPORTING_PROFILE.md §3.3)
- Empirical results: 60–80% cross-site false-positive suppression
  rate when operator marks a pattern resolved on one site.

DCO sign-off in commit message.