### PR TITLE
perf(server): server memory handling

### DIFF
--- a/server/lib/schema/cache.ex
+++ b/server/lib/schema/cache.ex
@@ -290,7 +290,13 @@ defmodule Schema.Cache do
           {name, attribute}
 
         base ->
-          {name, Utils.deep_merge(base, attribute)}
+          # Drop the dictionary attribute's `_links` back-reference: it lists
+          # every class using the attribute (O(n) per attribute), so keeping it
+          # on each enriched class is O(n^2) and, since the export is deep-copied
+          # out of the Repo Agent per request, inflates memory by >100 MiB.
+          # `_links` is internal and stripped from every response anyway (the
+          # detailed `enrich_ex/5` path drops it identically).
+          {name, Utils.deep_merge(base, attribute) |> Map.delete(:_links)}
       end
     end)
     |> Utils.add_sibling_of_to_attributes()

--- a/server/lib/schema/generator.ex
+++ b/server/lib/schema/generator.ex
@@ -100,10 +100,7 @@ defmodule Schema.Generator do
   end
 
   defp generate_classes(n, {_name, field}) do
-    valid_classes =
-      get_valid_classes(field)
-      |> Enum.shuffle()
-      |> Enum.take(n)
+    valid_classes = valid_classes_lazy(field) |> Enum.take(n)
 
     Enum.map(valid_classes, fn class ->
       generate_sample_class(class, Process.get(:profiles))
@@ -172,8 +169,9 @@ defmodule Schema.Generator do
               generate_object(field[:requirement], name, attribute, map)
 
             "class_t" ->
-              get_valid_classes(field)
-              |> Enum.random()
+              valid_classes_lazy(field)
+              |> Enum.take(1)
+              |> hd()
               |> generate_sample_class(Process.get(:profiles))
 
             nil ->
@@ -270,8 +268,9 @@ defmodule Schema.Generator do
 
       field[:type] == "class_t" ->
         generated =
-          get_valid_classes(field)
-          |> Enum.random()
+          valid_classes_lazy(field)
+          |> Enum.take(1)
+          |> hd()
           |> generate_sample_class(Process.get(:profiles))
 
         Map.put(map, name, generated)
@@ -933,32 +932,40 @@ defmodule Schema.Generator do
     end
   end
 
-  defp get_valid_classes(field) do
-    {all_classes_fn, class_fn} =
+  # Lazily yields valid sample classes for a `class_t` field.
+  #
+  # Candidate classes are selected as cheap keys from the simplified family map
+  # and materialized (via `Schema.class/2`, which enriches attributes) only as
+  # the caller pulls them.  Callers take at most a handful (`Enum.take/2`), so a
+  # single sample never enriches the entire — potentially hundreds-strong —
+  # family.  Keys are shuffled up front so `Enum.take(n)` yields a uniform
+  # random subset, matching the previous `Enum.shuffle |> Enum.take` /
+  # `Enum.random` selection.
+  defp valid_classes_lazy(field) do
+    {all_classes, class_fn} =
       case field[:family] do
         f when f in ["skill", "domain", "module"] ->
           fam_atom = String.to_atom(f)
           {Schema.all_classes(fam_atom), &Schema.class(fam_atom, &1)}
 
         _ ->
-          {[], fn _ -> nil end}
+          {%{}, fn _ -> nil end}
       end
 
     if field[:is_enum] do
-      Utils.find_children(all_classes_fn, field[:class_type])
+      # Reverse index {simplified class => key}, built once (O(n)).  Replaces the
+      # previous per-child full-map scan that made key recovery O(n^2).
+      key_by_value = Map.new(all_classes, fn {key, value} -> {value, key} end)
+
+      Utils.find_children(all_classes, field[:class_type])
       |> Enum.reject(fn child -> Map.get(child, :category) == true end)
       |> Enum.reject(& &1[:deprecated?])
-      |> Enum.map(fn child ->
-        Enum.find_value(all_classes_fn, fn {key, value} ->
-          if value == child, do: key, else: nil
-        end)
-        |> case do
-          nil -> nil
-          key -> class_fn.(key)
-        end
-      end)
+      |> Enum.map(&Map.get(key_by_value, &1))
       |> Enum.reject(&is_nil/1)
-      |> Enum.reject(&Map.has_key?(&1, :"@deprecated"))
+      |> Enum.shuffle()
+      |> Stream.map(class_fn)
+      |> Stream.reject(&is_nil/1)
+      |> Stream.reject(&Map.has_key?(&1, :"@deprecated"))
     else
       class_fn.(field[:class_type])
       |> List.wrap()

--- a/server/lib/schema/utils.ex
+++ b/server/lib/schema/utils.ex
@@ -487,11 +487,26 @@ defmodule Schema.Utils do
     |> Enum.map(fn {_key, elem} -> elem end)
   end
 
-  @spec find_children(map(), String.t()) :: [map()]
+  @spec find_children(map(), String.t() | nil) :: [map()]
   def find_children(map, parent_name) do
-    find_direct_children(map, parent_name)
+    # Index children by their parent (:extends) once, so the recursive descent
+    # is O(n) overall instead of rescanning the whole map for every node.
+    # Only entries carrying an :extends key are indexed, matching the semantics
+    # of find_direct_children/2.
+    by_parent =
+      map
+      |> Enum.map(fn {_key, elem} -> elem end)
+      |> Enum.filter(&Map.has_key?(&1, :extends))
+      |> Enum.group_by(& &1[:extends])
+
+    collect_descendants(by_parent, parent_name)
+  end
+
+  defp collect_descendants(by_parent, parent_name) do
+    by_parent
+    |> Map.get(parent_name, [])
     |> Enum.flat_map(fn elem ->
-      [elem | find_children(map, elem[:name])]
+      [elem | collect_descendants(by_parent, elem[:name])]
     end)
   end
 

--- a/server/test/schema/class_export_test.exs
+++ b/server/test/schema/class_export_test.exs
@@ -1,0 +1,43 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Schema.ClassExportTest do
+  @moduledoc """
+  Guards the memory cost of the class list endpoints (/api/skills, /api/domains,
+  /api/modules).
+
+  Enriching a class merges each attribute's definition from the dictionary.  A
+  dictionary attribute carries a `_links` back-reference to *every* class that
+  uses it, so copying it into each of the hundreds of classes is O(n^2).  The
+  enriched export is deep-copied out of the Repo Agent on every request, which
+  materialized >100 MiB and OOM-killed the pod under concurrent list requests.
+  Attribute `_links` are internal and stripped from every response, so they must
+  never be built into enriched classes in the first place.
+  """
+  use ExUnit.Case, async: false
+
+  test "enriched class attributes do not carry internal _links" do
+    for family <- [:skill, :domain, :module] do
+      Schema.Repo.classes(family)
+      |> Enum.each(fn {_key, class} ->
+        (class[:attributes] || [])
+        |> Enum.each(fn {attr_name, attr} ->
+          refute Map.has_key?(attr, :_links),
+                 "#{family} attribute #{inspect(attr_name)} still carries _links"
+        end)
+      end)
+    end
+  end
+
+  test "enriched skill export stays small (no O(n^2) _links blow-up)" do
+    mib =
+      Schema.Repo.classes(:skill)
+      |> :erlang.term_to_binary()
+      |> byte_size()
+      |> Kernel./(1_048_576)
+
+    assert mib < 5.0,
+           "enriched skill export is #{Float.round(mib, 1)} MiB; expected < 5 MiB " <>
+             "(dictionary _links are being copied into every class)"
+  end
+end

--- a/server/test/schema/generator_test.exs
+++ b/server/test/schema/generator_test.exs
@@ -1,0 +1,78 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Schema.GeneratorTest do
+  @moduledoc """
+  Tests for sample data generation.
+
+  The `record` object references the `skill`, `domain`, and `module` class
+  families through `class_t` enum attributes.  Generating a sample must only
+  materialize the handful of classes it actually samples — never the entire
+  family — otherwise per-request memory scales with the taxonomy size and the
+  server is OOM-killed under load (regression introduced by the granular
+  skills/domains taxonomy).
+  """
+  use ExUnit.Case, async: false
+
+  # Runs `fun` in a dedicated process and returns the reductions it consumed.
+  # Reductions are a deterministic proxy for work done (independent of GC
+  # timing), so they make a stable regression guard against re-materializing
+  # the whole class family per sample.
+  defp reductions(fun) do
+    parent = self()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        fun.()
+        {:reductions, red} = Process.info(self(), :reductions)
+        send(parent, {:reductions, red})
+      end)
+
+    receive do
+      {:reductions, red} ->
+        # Success: the reductions report is sent before the process exits, so it
+        # is received before the :DOWN. Flush the pending :DOWN and return.
+        Process.demonitor(ref, [:flush])
+        red
+
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        flunk("sample generation process crashed: #{inspect(reason)}")
+    after
+      60_000 ->
+        Process.demonitor(ref, [:flush])
+        Process.exit(pid, :kill)
+        flunk("sample generation timed out")
+    end
+  end
+
+  describe "generate_object/2 for the record object" do
+    test "produces valid, bounded skill/domain samples" do
+      record = Schema.object(nil, "record")
+      assert record, "record object must exist in the loaded schema"
+
+      sample = Schema.generate_object(record, nil)
+
+      skills = Map.get(sample, :skills) || Map.get(sample, "skills") || []
+      assert is_list(skills)
+      # The array generator caps skills at random(10); a sample must never emit
+      # one entry per class in the (hundreds-strong) taxonomy.
+      assert length(skills) <= 10
+
+      # Each generated skill is a class instance (a map), not a bare id/name.
+      Enum.each(skills, fn skill -> assert is_map(skill) end)
+    end
+
+    test "does not materialize the entire class family per sample" do
+      record = Schema.object(nil, "record")
+
+      red = reductions(fn -> Schema.generate_object(record, nil) end)
+
+      # Before the fix, generating one record sample materialized every skill
+      # (~500) and domain (~180) via an O(n^2) reverse lookup, costing ~7-8M
+      # reductions.  Selecting candidates lazily keeps it well under this bound.
+      assert red < 2_000_000,
+             "record sample used #{red} reductions; expected < 2_000_000 " <>
+               "(the whole class family is being materialized per sample)"
+    end
+  end
+end

--- a/server/test/schema/utils_test.exs
+++ b/server/test/schema/utils_test.exs
@@ -456,6 +456,34 @@ defmodule Schema.UtilsTest do
       map = %{leaf: %{name: "leaf", extends: "root"}}
       assert Utils.find_children(map, "leaf") == []
     end
+
+    test "returns every descendant with each ancestor before its descendants" do
+      map = %{
+        root: %{name: "root", extends: nil},
+        a: %{name: "a", extends: "root"},
+        a1: %{name: "a1", extends: "a"},
+        b: %{name: "b", extends: "root"}
+      }
+
+      names = Utils.find_children(map, "root") |> Enum.map(& &1[:name])
+      # Sibling order follows (unspecified) map iteration order, but the
+      # pre-order DFS invariant is guaranteed: a parent precedes its subtree
+      # and every descendant appears exactly once.
+      assert Enum.sort(names) == ["a", "a1", "b"]
+      assert Enum.find_index(names, &(&1 == "a")) < Enum.find_index(names, &(&1 == "a1"))
+    end
+
+    test "ignores entries without an :extends key (matching find_direct_children)" do
+      map = %{
+        no_extends: %{name: "no_extends"},
+        child: %{name: "child", extends: nil}
+      }
+
+      # find_direct_children requires the :extends key to be present, so an
+      # entry that lacks it is never treated as a child of nil.
+      names = Utils.find_children(map, nil) |> Enum.map(& &1[:name])
+      assert names == ["child"]
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the OOM crashes that led to `oasf-server` v1.1.0 being reverted from prod. The pod was `OOMKilled` (exit 137, surfacing as nginx **503 Bad Gateway**) — not a logic error. The granular skills/domains taxonomy (#475) grew the class families ~4× (122 → 496 skills, ~178 domains), which exposed several code paths whose **per-request memory scaled with the class count**. A single request could exceed the container memory limit, so any modest concurrency killed the pod.

## Root cause

| endpoint | why it blew up |
|---|---|
| `/sample/objects/record` (+ any `class_t` sample) | The sample generator materialized the **entire** class family (all ~496 skills / ~178 domains — each an `Agent.get` + `enrich`) via an **O(n²)** reverse lookup, even though a sample only needs `n ≤ 10`. |
| `/api/skills`, `/api/domains`, `/api/modules` | `enrich` deep-merged each dictionary attribute's `_links` back-reference (one entry per referencing class → O(n) per attribute) into **every** class → **O(n²)**. This structure is deep-copied out of the Repo Agent per request and then stripped from the response — pure waste. |
| `Utils.find_children/2` | Re-scanned the whole family map for every node → **O(n²)**; called on the sample and validation (scope-check) paths. |

## Changes

- **`generator.ex`** — select `class_t` candidates as cheap keys, shuffle, and materialize **lazily** (`Stream` + `Enum.take`) so a sample only enriches the handful it uses.
- **`cache.ex`** — drop the internal `_links` back-reference during attribute enrichment (matching the existing `enrich_ex/5` path). It is stripped from every response anyway; the dictionary page reads `_links` from the raw dictionary, so nothing observable changes.
- **`utils.ex`** — rewrite `find_children/2` from O(n²) to O(n) with a one-time parent index; behavior-identical (same `:extends` semantics, pre-order DFS).

## Impact (measured against the published v1.1.0 image, 1–2 GiB limit)

| | before | after |
|---|---|---|
| `/sample/objects/record` per request | ~460 MiB | **~5 MiB** |
| `/api/skills` per request | ~245 MiB | **~5 MiB** |
| record-sample reductions | 7.8M | **78K** |
| 25 concurrent `/api/skills` @ 2 GiB | **OOMKilled** | survives |
| mixed load that OOM'd @ 1 GiB | crash (503) | ~150 MiB, stable |
| steady-state working set | — | ~130–250 MiB |

## Correctness / safety

- HTTP responses are **byte-identical** to stock v1.1.0 across `/api/skills`, `/api/domains`, `/api/modules`, `/api/dictionary` (keeps its `_links`), `/api/skill_categories`, `/schema/objects/record`, and the rendered dictionary / object / class HTML pages (the only HTML diff observed is pre-existing non-deterministic enum ordering, reproducible on unchanged code).
- New regression tests:
  - `generator_test.exs` — record-sample correctness + a reductions bound (guards against re-materializing the whole family).
  - `class_export_test.exs` — enriched class attributes carry no `_links`; enriched skill export stays < 5 MiB (was 145.8 MiB).
  - `utils_test.exs` — `find_children` order/edge characterization.
- Full server suite: **366 tests, 0 failures**; `mix format` clean; `credo` clean for changed code.