### PR TITLE
fix(schema): validate extension files against their entity metaschema

### DIFF
--- a/schema/test/schema_test.go
+++ b/schema/test/schema_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const schemaDir = ".."
+const extensionFile = "extension.json"
 
 type SchemaFile struct {
 	Path string
@@ -106,7 +107,9 @@ var _ = Describe("Metaschema validation", func() {
 			{Dir: filepath.Join(schemaDir, "modules"), Schema: filepath.Join(metaschemaDir, "class.schema.json")},
 			{Dir: filepath.Join(schemaDir, "objects"), Schema: filepath.Join(metaschemaDir, "object.schema.json")},
 			{Dir: filepath.Join(schemaDir, "profiles"), Schema: filepath.Join(metaschemaDir, "profile.schema.json")},
-			{Dir: filepath.Join(schemaDir, "extensions"), Schema: filepath.Join(metaschemaDir, "extension.schema.json")},
+			// Extensions are deliberately absent here. An extension directory holds files of
+			// several different entity types, each governed by its own metaschema, so they are
+			// validated by the "Extension metaschema validation" spec below.
 		}
 
 		for _, target := range directories {
@@ -125,6 +128,54 @@ var _ = Describe("Metaschema validation", func() {
 
 			for _, file := range filesInDir {
 				if err := ValidateDataAgainstSchema(file.Data, target.Schema, file.Path); err != nil {
+					errors = append(errors, fmt.Sprintf("File %s failed validation: %s", file.Path, err))
+				}
+			}
+		}
+
+		if len(errors) > 0 {
+			Fail("Errors found:\n" + strings.Join(errors, "\n"))
+		}
+	})
+})
+
+var _ = Describe("Extension metaschema validation", func() {
+	It("should validate extension files against the metaschema for their entity type", func() {
+		var errors []string
+
+		metaschemaDir := filepath.Join(schemaDir, "metaschema")
+		extensionsDir := filepath.Join(schemaDir, "extensions")
+
+		dirInfo, err := os.Stat(extensionsDir)
+		if err != nil || !dirInfo.IsDir() {
+			AddWarning("%s directory does not exist\n", extensionsDir)
+			return
+		}
+
+		roots, err := FindExtensionRoots(extensionsDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		if len(roots) == 0 {
+			AddWarning("no extensions found in %s (an extension is a directory containing %s)", extensionsDir, extensionFile)
+			return
+		}
+
+		for _, root := range roots {
+			for _, file := range cache.Files {
+				if filepath.Ext(file.Path) != ".json" || !strings.HasPrefix(file.Path, root+string(os.PathSeparator)) {
+					continue
+				}
+
+				relPath, err := filepath.Rel(root, file.Path)
+				Expect(err).NotTo(HaveOccurred())
+
+				metaschema, known := ExtensionMetaschema(metaschemaDir, relPath)
+				if !known {
+					AddWarning("Skipping %s: no metaschema is defined for this location within an extension", file.Path)
+					continue
+				}
+
+				if err := ValidateDataAgainstSchema(file.Data, metaschema, file.Path); err != nil {
 					errors = append(errors, fmt.Sprintf("File %s failed validation: %s", file.Path, err))
 				}
 			}
@@ -456,4 +507,58 @@ func ValidateDataAgainstSchema(data []byte, schemaPath, filePath string) error {
 		return fmt.Errorf("schema validation failed for %s:\n%s", relPath, sb.String())
 	}
 	return nil
+}
+
+// FindExtensionRoots returns every directory under dir that directly contains an
+// extension.json file. This mirrors the schema server's extension discovery, which
+// registers a directory as an extension as soon as it finds extension.json and does
+// not descend any further (see server/lib/schema/json_reader.ex, find_extensions/2).
+func FindExtensionRoots(dir string) ([]string, error) {
+	var roots []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if _, err := os.Stat(filepath.Join(path, extensionFile)); err == nil {
+			roots = append(roots, path)
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	return roots, err
+}
+
+// ExtensionMetaschema maps a path relative to an extension root to the metaschema that
+// governs it. An extension mirrors the layout of the core schema directory, so each of
+// its files must be validated against the same metaschema as its core counterpart
+// rather than against extension.schema.json (see CONTRIBUTING.md). The second return
+// value reports whether a metaschema is defined for the given location.
+func ExtensionMetaschema(metaschemaDir, relPath string) (string, bool) {
+	relPath = filepath.ToSlash(relPath)
+
+	switch relPath {
+	case extensionFile:
+		return filepath.Join(metaschemaDir, "extension.schema.json"), true
+	case "dictionary.json":
+		return filepath.Join(metaschemaDir, "dictionary.schema.json"), true
+	}
+
+	top, _, nested := strings.Cut(relPath, "/")
+	if !nested {
+		return "", false
+	}
+
+	switch top {
+	case "skills", "domains", "modules":
+		return filepath.Join(metaschemaDir, "class.schema.json"), true
+	case "objects":
+		return filepath.Join(metaschemaDir, "object.schema.json"), true
+	case "profiles":
+		return filepath.Join(metaschemaDir, "profile.schema.json"), true
+	}
+
+	return "", false
 }

--- a/schema/test/schema_test.go
+++ b/schema/test/schema_test.go
@@ -155,6 +155,16 @@ var _ = Describe("Extension metaschema validation", func() {
 		roots, err := FindExtensionRoots(extensionsDir)
 		Expect(err).NotTo(HaveOccurred())
 
+		unclaimed, err := FindUnclaimedDirs(extensionsDir, roots)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, dir := range unclaimed {
+			AddWarning(
+				"Skipping %s: it holds JSON files but no %s, so it is not an extension and nothing in it was validated",
+				dir, extensionFile,
+			)
+		}
+
 		if len(roots) == 0 {
 			AddWarning("no extensions found in %s (an extension is a directory containing %s)", extensionsDir, extensionFile)
 			return
@@ -529,6 +539,52 @@ func FindExtensionRoots(dir string) ([]string, error) {
 		return nil
 	})
 	return roots, err
+}
+
+// FindUnclaimedDirs returns every directory under dir that holds JSON files directly but
+// belongs to no extension root. That is the shape a misspelled extension.json produces: the
+// schema server does not register the directory as an extension, so nothing in it is read,
+// and this spec does not validate it either. Reporting it turns a silent omission into a
+// warning without changing what counts as an extension. Directories that merely group
+// extensions hold no JSON of their own and are not reported.
+func FindUnclaimedDirs(dir string, roots []string) ([]string, error) {
+	var unclaimed []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		for _, root := range roots {
+			if path == root || strings.HasPrefix(path, root+string(os.PathSeparator)) {
+				return filepath.SkipDir
+			}
+		}
+		hasJSON, err := DirHasJSONFile(path)
+		if err != nil {
+			return err
+		}
+		if hasJSON {
+			unclaimed = append(unclaimed, path)
+		}
+		return nil
+	})
+	return unclaimed, err
+}
+
+// DirHasJSONFile reports whether dir directly contains a .json file, ignoring subdirectories.
+func DirHasJSONFile(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".json" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // ExtensionMetaschema maps a path relative to an extension root to the metaschema that


### PR DESCRIPTION
# fix(schema): validate extension files against their entity metaschema

## Problem

`schema/test/schema_test.go` validates every `.json` file under `schema/extensions/` against `metaschema/extension.schema.json`:

```go
{Dir: filepath.Join(schemaDir, "extensions"), Schema: filepath.Join(metaschemaDir, "extension.schema.json")},
```

The match is a recursive path-prefix match, so it reaches every file in every subdirectory of an extension. But `extension.schema.json` requires `description`, `caption`, `name` and `uid` and sets `additionalProperties: false` — it describes `extension.json` and nothing else.

An extension mirrors the layout of the core `schema` directory, as described in `CONTRIBUTING.md`. Its `dictionary.json`, `domains/`, `skills/`, `modules/`, `objects/` and `profiles/` files are governed by the same metaschemas as their core counterparts. Validating them against `extension.schema.json` makes every one of them fail, so `task test:schema` cannot pass for any in-tree extension.

The bug is currently invisible because `schema/extensions/` does not exist on `main`. It surfaces as soon as anyone follows the documented extension workflow.

Reproduced against `main` by dropping a minimal extension into `schema/extensions/example/`:

```
File ../extensions/example/dictionary.json failed validation:
  (root): uid is required
  (root): Additional property attributes is not allowed
File ../extensions/example/domains/example_verticals/example_verticals.json failed validation:
  (root): Additional property extends is not allowed
  (root): Additional property category is not allowed
  (root): Additional property attributes is not allowed
File ../extensions/example/modules/example_telemetry.json failed validation: ...
File ../extensions/example/objects/example_telemetry_data.json failed validation: ...
```

## Change

`extensions` is removed from the flat directory list and gets its own spec. Discovery mirrors the schema server: a directory containing `extension.json` is an extension root and its subdirectories belong to it — the same rule as `find_extensions/2` in `server/lib/schema/json_reader.ex`. Each file is then validated against the metaschema for its entity type:

| Location within an extension | Metaschema |
| --- | --- |
| `extension.json` | `extension.schema.json` |
| `dictionary.json` | `dictionary.schema.json` |
| `skills/`, `domains/`, `modules/` | `class.schema.json` |
| `objects/` | `object.schema.json` |
| `profiles/` | `profile.schema.json` |

Files in locations with no defined metaschema are reported through the existing `AddWarning` mechanism rather than failing the suite, so an extension carrying additional JSON does not break the build.

## Verification

Run from `schema/test`:

| Scenario | Result |
| --- | --- |
| Fix + an in-tree extension | `ok schema` — 6 of 6 specs pass |
| `main`'s test file + the same extension | 1 spec fails, 5 files rejected (output above) |
| Fix + no `schema/extensions/` directory | `ok schema` — unchanged behaviour for the current tree |

The Go diff introduces no `gofmt` drift beyond what is already on `main`.

## Notes

This PR is the test fix alone. The reference example extension it was originally bundled with is now a separate PR, stacked on this one, since it is only mergeable once this lands.

One known gap, called out for the record: a directory under `extensions/` that lacks `extension.json` is not discovered, so its files are neither validated nor warned about — a contributor who misspells the filename sees a green suite. That matches the schema server's own behaviour (it registers an extension only on finding `extension.json`), so this PR reproduces it deliberately rather than inventing a second discovery rule. Note that before this change such a directory was not validated either: every file in it hard-failed against `extension.schema.json`. Happy to add a warning for undiscovered directories under `extensions/` if you would like the signal.

The commit is signed off per the DCO.
