### PR TITLE
feat(schema): add a reference example extension

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,6 +208,9 @@ jobs:
       - name: OASF Server Validation
         run: task test:server
 
+      - name: OASF Server Validation with extensions loaded
+        run: task test:server:extensions
+
       - name: Generate OASF server coverage report
         working-directory: server
         run: mix coveralls.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -204,6 +204,7 @@ tasks:
       - task: test:schema
       - task: test:proto
       - task: test:server
+      - task: test:server:extensions
 
   test:e2e:
     desc: Deploy to an ephemeral kind cluster and verify the server starts healthy
@@ -237,6 +238,18 @@ tasks:
     dir: '{{ .ROOT_DIR }}/server'
     cmds:
       - cmd: echo "Running OASF server test suite..."
+      - cmd: mix test
+
+  test:server:extensions:
+    desc: Test server code with the in-tree extensions loaded
+    preconditions:
+      - which mix
+    dir: '{{ .ROOT_DIR }}/server'
+    env:
+      SCHEMA_DIR: '{{ .ROOT_DIR }}/schema'
+      SCHEMA_EXTENSION: extensions
+    cmds:
+      - cmd: echo "Running OASF server test suite with extensions loaded..."
       - cmd: mix test
 
   lint:

--- a/schema/extensions.md
+++ b/schema/extensions.md
@@ -6,5 +6,6 @@ The purpose of this file is to keep track of and avoid collisions in Extension
 | Caption                             | Name | UID     | Notes                                    |
 | ----------------------------------- | ---- | ------- | ---------------------------------------- |
 | Development                         | dev  | **999** | The development (TODO) schema extensions |
+| Example                             | example | **998** | Reference extension, see `schema/extensions/example` |
 | _Native Extensions defined in OASF_ |
 |                                     |      |         |                                          |

--- a/schema/extensions/example/README.md
+++ b/schema/extensions/example/README.md
@@ -14,7 +14,7 @@ An extension mirrors the layout of the core `schema` directory:
 | `extension.json` | Declares the extension's `name` and `uid`. A directory becomes an extension by containing this file. |
 | `dictionary.json` | New attributes contributed by the extension. |
 | `domains/` | New domain classes. A class becomes a category by setting `"category": true`. |
-| `modules/` | New module classes. A module overrides `data` with its own payload object. |
+| `modules/` | New module classes. Like domains, these are a category plus the classes that extend it; a module overrides `data` with its own payload object. |
 | `objects/` | New objects, including module payload objects, which extend `module_data`. |
 
 `skills/` and `profiles/` follow the same pattern and are omitted here for brevity.
@@ -49,6 +49,24 @@ into a record as:
 The name is the category path followed by `<extension_name>_<class_name>`. The
 identifier is derived as `(extension_uid * 100 + category_uid) * 100 + class_uid`,
 here `(998 * 100 + 1) * 100 + 1`.
+
+## Every class needs a category, modules included
+
+The same applies to modules, and it is easy to miss because a module can extend
+`base_module` directly and still load. It should not: `base_module` is not a category,
+so such a module gets no category segment, its identifier folds against category `0`,
+and it renders as a sibling of the top-level module groups rather than as a member of
+one. No core module does this — `core` and `integration` are categories, and
+`observability` and `a2a` extend them.
+
+That is why this extension defines `modules/example_modules/example_modules.json` as a
+category and has `example_telemetry` extend it, exactly as `domains/` does:
+
+```json
+{ "name": "example/example_modules/example_example_telemetry", "id": 9980101 }
+```
+
+Extending `base_module` directly instead yields `id` 9980001 with `category: null`.
 
 ## Module payloads
 

--- a/schema/extensions/example/README.md
+++ b/schema/extensions/example/README.md
@@ -1,0 +1,65 @@
+# Example Extension
+
+A minimal, working reference extension. It exists so that the extension mechanism
+documented in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) and
+[`server/README.md`](../../../server/README.md) has a concrete example to point at,
+and so that the schema test suite exercises the extension validation path.
+
+## Layout
+
+An extension mirrors the layout of the core `schema` directory:
+
+| Path | Purpose |
+| --- | --- |
+| `extension.json` | Declares the extension's `name` and `uid`. A directory becomes an extension by containing this file. |
+| `dictionary.json` | New attributes contributed by the extension. |
+| `domains/` | New domain classes. A class becomes a category by setting `"category": true`. |
+| `modules/` | New module classes. A module overrides `data` with its own payload object. |
+| `objects/` | New objects, including module payload objects, which extend `module_data`. |
+
+`skills/` and `profiles/` follow the same pattern and are omitted here for brevity.
+
+## Loading it
+
+```shell
+SCHEMA_DIR=../schema SCHEMA_EXTENSION=extensions iex -S mix phx.server
+```
+
+Then, from the `iex` prompt:
+
+```elixir
+Schema.reload(["extensions/example"])
+```
+
+## Naming
+
+Extension entities are keyed as `<extension_name>/<entity_name>`, so a reference from
+one extension entity to another must carry that prefix. `cold_chain_logistics.json`
+extends `example/example_verticals`, not `example_verticals`: an unqualified `extends`
+does not resolve, the class is left without a category, and its identifier is computed
+against category `0`.
+
+The class defined in `domains/example_verticals/cold_chain_logistics.json` is written
+into a record as:
+
+```json
+{ "name": "example/example_verticals/example_cold_chain_logistics", "id": 9980101 }
+```
+
+The name is the category path followed by `<extension_name>_<class_name>`. The
+identifier is derived as `(extension_uid * 100 + category_uid) * 100 + class_uid`,
+here `(998 * 100 + 1) * 100 + 1`.
+
+## Module payloads
+
+A module overrides `data` with a `reference` to its own payload object, and the
+dictionary entry for that payload is *self-typed* — its `type` is the object's own
+name, as `observability_data` is in the core dictionary. Without that entry the
+reference does not resolve, `data` silently falls back to `string_t`, and the schema
+fails to compile.
+
+## Reserving a UID
+
+Before publishing an extension, reserve its name and `uid` in
+[`schema/extensions.md`](../../extensions.md) to avoid collisions with the core
+schema and with other extensions.

--- a/schema/extensions/example/dictionary.json
+++ b/schema/extensions/example/dictionary.json
@@ -1,0 +1,22 @@
+{
+  "caption": "Example Extension Attribute Dictionary",
+  "description": "Attributes contributed by the example extension. Extension attributes are namespaced by the extension name unless they are declared in the core dictionary.",
+  "name": "dictionary",
+  "attributes": {
+    "example_endpoint": {
+      "caption": "Example Endpoint",
+      "description": "URL of the endpoint that the example telemetry module reports to.",
+      "type": "string_t"
+    },
+    "example_sample_rate": {
+      "caption": "Example Sample Rate",
+      "description": "Percentage of events reported by the example telemetry module, from 0 to 100.",
+      "type": "integer_t"
+    },
+    "example_telemetry_data": {
+      "caption": "Data",
+      "description": "Telemetry configuration supported by the agent. Module payload objects are self-typed in the dictionary so that the module's data attribute resolves to the object rather than to a string.",
+      "type": "example_telemetry_data"
+    }
+  }
+}

--- a/schema/extensions/example/domains/example_verticals/cold_chain_logistics.json
+++ b/schema/extensions/example/domains/example_verticals/cold_chain_logistics.json
@@ -1,0 +1,8 @@
+{
+  "uid": 1,
+  "caption": "Cold Chain Logistics",
+  "description": "Temperature-controlled storage and transport of perishable goods.",
+  "extends": "example/example_verticals",
+  "name": "cold_chain_logistics",
+  "attributes": {}
+}

--- a/schema/extensions/example/domains/example_verticals/example_verticals.json
+++ b/schema/extensions/example/domains/example_verticals/example_verticals.json
@@ -1,0 +1,9 @@
+{
+  "uid": 1,
+  "caption": "Example Verticals",
+  "description": "Example category showing how an extension contributes a new branch to the domain taxonomy.",
+  "extends": "base_domain",
+  "name": "example_verticals",
+  "category": true,
+  "attributes": {}
+}

--- a/schema/extensions/example/extension.json
+++ b/schema/extensions/example/extension.json
@@ -1,0 +1,7 @@
+{
+  "caption": "Example",
+  "description": "A minimal reference extension demonstrating how to extend OASF without modifying the core schema.",
+  "name": "example",
+  "uid": 998,
+  "version": "0.1.0"
+}

--- a/schema/extensions/example/modules/example_modules/example_modules.json
+++ b/schema/extensions/example/modules/example_modules/example_modules.json
@@ -1,0 +1,9 @@
+{
+  "uid": 1,
+  "caption": "Example Modules",
+  "description": "Example module category showing how an extension contributes a new branch to the module taxonomy.",
+  "extends": "base_module",
+  "name": "example_modules",
+  "category": true,
+  "attributes": {}
+}

--- a/schema/extensions/example/modules/example_modules/example_telemetry.json
+++ b/schema/extensions/example/modules/example_modules/example_telemetry.json
@@ -2,7 +2,7 @@
   "uid": 1,
   "caption": "Example Telemetry",
   "description": "Example module showing how an extension defines its own module payload by overriding the data attribute.",
-  "extends": "base_module",
+  "extends": "example/example_modules",
   "name": "example_telemetry",
   "attributes": {
     "data": {

--- a/schema/extensions/example/modules/example_telemetry.json
+++ b/schema/extensions/example/modules/example_telemetry.json
@@ -1,0 +1,15 @@
+{
+  "uid": 1,
+  "caption": "Example Telemetry",
+  "description": "Example module showing how an extension defines its own module payload by overriding the data attribute.",
+  "extends": "base_module",
+  "name": "example_telemetry",
+  "attributes": {
+    "data": {
+      "reference": "example_telemetry_data",
+      "caption": "Data",
+      "description": "Telemetry configuration supported by the agent.",
+      "requirement": "required"
+    }
+  }
+}

--- a/schema/extensions/example/objects/example_telemetry_data.json
+++ b/schema/extensions/example/objects/example_telemetry_data.json
@@ -1,0 +1,14 @@
+{
+  "caption": "Example Telemetry Data",
+  "description": "Payload of the example telemetry module. Module payload objects extend module_data.",
+  "extends": "module_data",
+  "name": "example_telemetry_data",
+  "attributes": {
+    "example_endpoint": {
+      "requirement": "required"
+    },
+    "example_sample_rate": {
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
# feat(schema): add a reference example extension

> Stacked on #488. Opened early at @akijakya's request, so the two can be reviewed side by side and #488's new spec has something to act on — the commits shared with #488 collapse to nothing when it merges.

## Problem

`server/README.md` documents `Schema.reload(["extensions/example"])` and `CONTRIBUTING.md` describes creating a subdirectory under `extensions/`, but no example extension exists. The documented path has never been exercised, and two of its requirements are not written down anywhere:

- a reference between two entities of the same extension must be scoped `<extension_name>/<entity_name>`, because that is how extension entities are keyed;
- a module payload object needs a *self-typed* dictionary entry, the way `observability_data` has one in `schema/dictionary.json`, or the module's `data` attribute silently degrades to `string_t`.

Both are load-bearing and both fail quietly — the second produces a compile error in the log and a `String`-typed attribute in the export.

## Change

A minimal extension under `schema/extensions/example/`: `extension.json`, `dictionary.json`, a domain category with one leaf class, a module, and a module payload object extending `module_data`. Name `example` / uid `998` is reserved in `schema/extensions.md`.

Its README covers the directory layout, how to load it, how entity names and identifiers are derived, and the two requirements above — with the worked derivation `(998 * 100 + 1) * 100 + 1 = 9980101`.

It also serves as the fixture that exercises the extension validation path added by #488. That spec is dormant on `main` — with no `schema/extensions/` directory it takes the "does not exist" warning path and cannot fail — so this PR is what puts it under load: `task test:schema` here validates six real files across five metaschemas.

**Module category (`feat(schema): give the example module a category`)**

`example_telemetry` originally extended `base_module` directly. `base_module` is not a category, so the module got no category segment: uid `9980001` folded against category `0`, `category: nil`, rendering as a sibling of the top-level module groups rather than a member of one — the same failure the README warns about for domains, in the half the README did not describe. Adds `modules/example_modules/example_modules.json` mirroring `core.json` and reparents the module onto it.

**CI (`ci: run the server test suite with the in-tree extensions loaded`)**

Nothing in `Taskfile.yml` or `.github/workflows` set `SCHEMA_EXTENSION`, so the server suite never loaded an extension no matter what was in the tree. Adds `test:server:extensions`, wired into the aggregate `test` task and the CI job. It is a separate task rather than a change to `test:server` so the existing no-extensions run keeps its own signal — the two catch different failures.

## Verification

From `server/`, on this branch:

| Scenario | Result |
| --- | --- |
| `mix test` (no extension loaded) | 366 passed |
| `SCHEMA_DIR=../schema SCHEMA_EXTENSION=extensions mix test` | 366 passed |

Derived values confirmed against a loaded schema rather than by inspection:

```
domain example/cold_chain_logistics
  uid            9980101
  category       example_verticals  ("Example Verticals")
  name enum      example/example_verticals/example_cold_chain_logistics

module example/example_telemetry
  uid            9980101
  category       example_modules    ("Example Modules")
  name enum      example/example_modules/example_example_telemetry
  data           object_t -> example/example_telemetry_data
```

`find_class` resolves `9980001` to each category and `9980101` to each leaf, in both families.

All three task entry points, as CI runs them:

| Task | Result |
| --- | --- |
| `task test:schema` | 7 of 7 specs, SUCCESS |
| `task test:server` | 366 passed |
| `task test:server:extensions` | 366 passed |

The new CI task was checked for teeth rather than assumed: reverting this extension's `extends` to the unqualified form makes it fail with `domains with invalid extends: [:"example/cold_chain_logistics"]`, and it returns to 366 once restored. A CI step that cannot fail would have reproduced the gap it exists to close.

All commits are signed off per the DCO.
