### PR TITLE
docs(schema): reserve the caaf extension name and uid 240

### DIFF
--- a/schema/extensions.md
+++ b/schema/extensions.md
@@ -7,5 +7,6 @@ The purpose of this file is to keep track of and avoid collisions in Extension
 | ----------------------------------- | ---- | ------- | ---------------------------------------- |
 | Development                         | dev  | **999** | The development (TODO) schema extensions |
 | Example                             | example | **998** | Reference extension, see `schema/extensions/example` |
+| Clinical Agent Assurance            | caaf | **240** | Clinical agent assurance for health AI   |
 | _Native Extensions defined in OASF_ |
 |                                     |      |         |                                          |


### PR DESCRIPTION
# docs(schema): reserve the caaf extension name and uid 240

## What

One row in `schema/extensions.md`, reserving the extension name `caaf` and uid `240`.

```
| Clinical Agent Assurance            | caaf | **240** | Clinical agent assurance for health AI   |
```

Documentation only. No schema files are added, nothing under `schema/extensions/` is created, and no build, test or generated output is affected. Column widths match the existing rows, so the table needs no reformatting.

## Why this file

`schema/extensions.md` states its own purpose: "to keep track of and avoid collisions in Extension `names` & `id`s." Registering before publishing is what makes that work. `caaf` and `240` are both currently unused on `main`.

uid `240` was picked to sit clear of `dev` (999) and of the low range native extensions are likely to want. I have no attachment to the number — see the question below.

## What `caaf` is

Clinical Agent Assurance: assurance attributes for agents that operate on protected health information. Data-handling profile, authorization scope, autonomy tier, human oversight, evaluation policy. Maintained by SciEncephalon AI.

Unlike a bare reservation, the extension exists and loads. Measured against this branch with the extension placed in-tree:

```
task test:schema                              7 of 7 specs, SUCCESS
SCHEMA_EXTENSION=extensions mix test          366 passed

domain caaf/care_transitions   uid 2400101  category clinical_care
domain caaf/population_risk    uid 2400105  category clinical_care
module caaf/clinical_assurance uid 2400101  category clinical
```

Worth noting this is only verifiable as of #488. Before that fix, no in-tree extension could pass `task test:schema` at all, so "validates against the metaschemas" was not a claim anyone could actually check.

I am not asking to add those files here. This PR is the registry row only; the extension will be published separately once the name is settled.

## A question about process, which matters more than my row

[#471](https://github.com/agntcy/oasf/pull/471) asked for the same thing — a namespace reservation, `agentminds_io` — on **27 April 2026**. It has been open four months with zero comments and zero reviews. It took a different approach, adding a `README.md` under `schema/extensions/` rather than editing the registry file.

So there are two conventions in play and no signal about which is right, and a contributor who followed one of them has been waiting since April.

Rather than add a second unanswered request, I would rather ask directly:

1. **Is a PR the intended way to reserve an extension name and uid?** If maintainers would rather allocate these some other way, say so and I will withdraw this and follow that route.
2. **If it is, which file?** This PR edits `schema/extensions.md`, which documents itself as the collision registry. #471 adds a README. Whichever you prefer, I will match it, and I am happy to update this PR to the other shape.
3. **Is 240 acceptable, or should extensions allocate from a specific range?** Happy to take any number.

If the answer to (1) is yes, #471 has been waiting considerably longer than I have and should probably go first.

## Note on ordering

[#489](https://github.com/agntcy/oasf/pull/489) also adds a row to this table, reserving `example` / `998` for the reference extension. The two will conflict textually depending on merge order; whichever lands second, I will rebase. No coordination needed on your side.
