### PR TITLE
fix(schema): enforce a floor on extension uids

### DIFF
--- a/schema/extensions.md
+++ b/schema/extensions.md
@@ -1,11 +1,20 @@
 # OASF Extensions Registry
 
-The purpose of this file is to keep track of and avoid collisions in Extension
-`names` & `id`s.
+The purpose of this file is to keep track of and avoid collisions in Extension `names` and `uid`s.
 
-| Caption                             | Name | UID     | Notes                                    |
-| ----------------------------------- | ---- | ------- | ---------------------------------------- |
-| Development                         | dev  | **999** | The development (TODO) schema extensions |
-| Example                             | example | **998** | Reference extension, see `schema/extensions/example` |
-| _Native Extensions defined in OASF_ |
-|                                     |      |         |                                          |
+## Allocating a uid
+
+Extensions allocate **downwards from 999**. A new extension takes the next unused uid below the lowest one already listed. Reserve it here, by pull request, before publishing the extension.
+
+The `uid` must be **between 100 and 999**, and the metaschema enforces the lower bound. An extension's classes are numbered `(uid * 100 + category_uid) * 100 + class_uid`, while a core class is numbered `category_uid * 10000 + subcategory_uid * 100 + class_uid`. An extension uid below 100 therefore produces class identifiers indistinguishable from core ones — uid 1 with category 3 and class 1 yields `10301`, which is already `language_processing/language_generation/text_completion`.
+
+Identifiers are packed two decimal digits per level, so this only holds while every `category_uid` and `class_uid` stays below 100. That is now enforced too: `class.schema.json` caps a class `uid` at 99, where it previously allowed 999 and a three-digit value silently overflowed into the neighbouring category.
+
+The floor of 100 is therefore a reciprocal commitment: extensions stay at or above it, and the core taxonomy keeps its category uids below it. That leaves 900 extension uids and room for 99 categories in each of `skills`, `domains`, and `modules`, against the 18, 24, and 2 defined today. Category uids are scoped per family, so each grows independently.
+
+`Repository` is optional. Use it when the extension schema is public. Leave it blank for private extensions or when the schema is not published.
+
+| Caption     | Name    | UID     | Notes                                                | Repository                                    |
+| ----------- | ------- | ------- | ---------------------------------------------------- | --------------------------------------------- |
+| Development | dev     | **999** | The development (TODO) schema extensions             |                                               |
+| Example     | example | **998** | Reference extension demonstrating the mechanism      | [schema/extensions/example](extensions/example/) |

--- a/schema/metaschema/class.schema.json
+++ b/schema/metaschema/class.schema.json
@@ -35,9 +35,9 @@
         },
         "uid": {
           "type": "integer",
-          "description": "A unique identifier for this class, must be unique within the category and class level.",
+          "description": "A unique identifier for this class, must be unique within the category and class level. Identifiers are packed two decimal digits per level, so this must stay below 100 -- a larger value overflows into the neighbouring category.",
           "minimum": 0,
-          "maximum": 999
+          "maximum": 99
         }
       },
       "additionalProperties": false

--- a/schema/metaschema/extension.schema.json
+++ b/schema/metaschema/extension.schema.json
@@ -26,8 +26,8 @@
     },
     "uid": {
       "type": "integer",
-      "minimum": 0,
-      "description": "The unique identifier for this extension."
+      "minimum": 100,
+      "description": "The unique identifier for this extension. Must be at least 100: an extension's class identifiers are computed as (uid * 100 + category_uid) * 100 + class_uid, so a lower uid would produce identifiers that collide with core classes. See schema/extensions.md."
     },
     "version": {
       "description": "The version of this extension",

--- a/server/test/schema_web/controllers/schema_controller_test.exs
+++ b/server/test/schema_web/controllers/schema_controller_test.exs
@@ -16,22 +16,30 @@ defmodule SchemaWeb.SchemaControllerTest do
 
   # Names are derived at runtime from the live schema so the tests remain
   # robust against future taxonomy changes.  Each helper picks the first
-  # suitable entry from the loaded schema rather than hard-coding a name.
+  # suitable entry in sorted order rather than hard-coding a name.
+  #
+  # Sorting matters: the schema is held in a map, so iteration order is not
+  # stable across environments, and picking an arbitrary entry makes these
+  # tests pass or fail by luck. Extension entities are excluded because their
+  # keys are scoped as `<extension>/<name>`, which the single-segment
+  # `/api/{translate,validate}/object/:name` routes cannot address.
+
+  defp first_unscoped(entries, suitable?) do
+    entries
+    |> Enum.filter(fn {k, v} ->
+      suitable?.(v) and not String.contains?(Atom.to_string(k), "/")
+    end)
+    |> Enum.map(fn {k, _v} -> Atom.to_string(k) end)
+    |> Enum.sort()
+    |> List.first()
+  end
 
   defp test_class_name(family) do
-    {name, _} =
-      Schema.all_classes(family)
-      |> Enum.find(fn {_k, v} -> v[:category] != true end)
-
-    Atom.to_string(name)
+    first_unscoped(Schema.all_classes(family), &(&1[:category] != true))
   end
 
   defp test_class_category_name(family) do
-    {name, _} =
-      Schema.all_classes(family)
-      |> Enum.find(fn {_k, v} -> v[:category] == true end)
-
-    Atom.to_string(name)
+    first_unscoped(Schema.all_classes(family), &(&1[:category] == true))
   end
 
   defp test_skill_name, do: test_class_name(:skill)
@@ -43,8 +51,7 @@ defmodule SchemaWeb.SchemaControllerTest do
   defp test_module_category_name, do: test_class_category_name(:module)
 
   defp test_object_name do
-    {name, _} = Schema.all_objects() |> Enum.find(fn {_k, _v} -> true end)
-    Atom.to_string(name)
+    first_unscoped(Schema.all_objects(), fn _ -> true end)
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Enforces the two invariants that OASF's identifier packing has always assumed but never checked, and fixes a test whose result depended on map iteration order.

- `extension.schema.json` — extension `uid` gains `minimum: 100`.
- `class.schema.json` — class `uid` maximum drops from `999` to `99`.
- `schema/extensions.md` — documents the allocation convention adopted from OCSF: extensions take the next free uid counting down from 999.
- `schema_controller_test.exs` — test entity names are now selected deterministically.

## Why

Identifiers are packed two decimal digits per level. An extension's classes are numbered `(uid * 100 + category_uid) * 100 + class_uid`, a core class as `category_uid * 10000 + subcategory_uid * 100 + class_uid`. That scheme only separates extension identifiers from core ones while every level stays in its two digits, and neither end was enforced:

- An extension uid below 100 produces identifiers indistinguishable from core ones. Uid 1 with category 3 and class 1 yields `10301`, which is already `language_processing/language_generation/text_completion`.
- A class uid of 100 or more overflows into the neighbouring category, silently. The metaschema permitted up to 999.

The floor is a reciprocal commitment: extensions stay at or above 100, and the core taxonomy keeps its category uids below it. That leaves 900 extension uids and room for 99 categories in each entity family, against the 18, 24 and 2 defined today.

## The test fix

`test_class_name/1`, `test_class_category_name/1` and `test_object_name/0` each picked an entry with `Enum.find` over a map, so which entity the tests exercised came down to map iteration order rather than anything the test controlled. With extensions loaded the candidate set includes scoped keys such as `example/example_telemetry_data`, and `POST /api/{translate,validate}/object/:name` is single-segment, so a name containing a slash cannot be addressed — the pick decided whether five tests passed or returned 404. The suite was green locally and red in CI on identical code.

They now select the alphabetically first unscoped entity. Extension entities are excluded rather than accommodated: every GET object route has an `:extension/:name` variant and the two POST routes do not, which is a real gap but a separate one, and out of scope here.

## Breaking

Both metaschema changes reject input that previously validated:

- an extension with a `uid` below 100
- a class with a `uid` of 100 or more

Nothing in-tree is affected — the only extension is `example` at 998, and no class or object anywhere in `schema/` has a uid above 99 — but an out-of-tree extension can break on upgrade. That is the intent in both cases, since such values were already minting colliding identifiers.

## Verification

`task test:schema` 7/7, `task test:proto` 5/5, `task test:server` 366, `task test:server:extensions` 366, `task lint` clean.

Confirmed each bound has teeth rather than assuming it: setting the example extension's uid to `50` fails at `schema/test/schema_test.go:195` and passes again at `998`. For the test fix, the selection changed from an arbitrary `openapi_security_scheme` to a deterministic `a2a_data`, with `example/example_telemetry_data` — the only scoped object in the set, and the one CI picked — now unreachable by construction.

Context: #492 and #471 both asked how to reserve an extension uid, and neither had a convention to follow.
